### PR TITLE
[Android] Bluetooth 권한과 관련된 불필요한 설정 확인

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
     <uses-permission android:name="android.permission.INTERNET"/>
 
+    <!-- legacy for Android 11 or lower -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"
@@ -52,17 +55,4 @@
             <data android:scheme="https" />
         </intent>
     </queries>
-
-    <!-- Tell Google Play Store that your app uses Bluetooth LE
-     Set android:required="true" if bluetooth is necessary -->
-    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
-
-    <!-- New Bluetooth permissions in Android 12
-    https://developer.android.com/about/versions/12/features/bluetooth-permissions -->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
-
-    <!-- legacy for Android 11 or lower -->
-    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-
 </manifest>

--- a/android/app/src/regtest/AndroidManifest.xml
+++ b/android/app/src/regtest/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
 
+    <!-- legacy for Android 11 or lower -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"
@@ -49,17 +52,4 @@
             <data android:mimeType="text/plain"/>
         </intent>
     </queries>
-
-    <!-- Tell Google Play Store that your app uses Bluetooth LE
-     Set android:required="true" if bluetooth is necessary -->
-    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
-
-    <!-- New Bluetooth permissions in Android 12
-    https://developer.android.com/about/versions/12/features/bluetooth-permissions -->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
-
-    <!-- legacy for Android 11 or lower -->
-    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-
 </manifest>

--- a/android/app/src/regtestlocal/AndroidManifest.xml
+++ b/android/app/src/regtestlocal/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
 
+    <!-- legacy for Android 11 or lower -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"
@@ -49,17 +52,4 @@
             <data android:mimeType="text/plain"/>
         </intent>
     </queries>
-
-    <!-- Tell Google Play Store that your app uses Bluetooth LE
-     Set android:required="true" if bluetooth is necessary -->
-    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
-
-    <!-- New Bluetooth permissions in Android 12
-    https://developer.android.com/about/versions/12/features/bluetooth-permissions -->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
-
-    <!-- legacy for Android 11 or lower -->
-    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-
 </manifest>


### PR DESCRIPTION
### 📝 Description

`AndroidManifest.xml`
```xml
    <!-- 앱에서 저전력 블루투스를 사용하는 경우 -->
    <!-- Tell Google Play Store that your app uses Bluetooth LE
     Set android:required="true" if bluetooth is necessary -->
    <!--<uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />-->

    <!-- 앱에서 블루투스 기기를 찾는 경우 -->
    <!-- New Bluetooth permissions in Android 12
    https://developer.android.com/about/versions/12/features/bluetooth-permissions -->
    <!--<uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />-->

    <!-- legacy for Android 11 or lower -->
    <!-- 필수 항목 -->
    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
    <!-- 기기 검색 등 설정 -->
    <!--<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />-->
```

위와 같이 기존에 설정되어 있는 권한 중 필수 권한은 `android.permission.BLUETOOTH` 이며 나머지는 필요에 따라 추가하는 권한으로 확인되었습니다. 현재 프로젝트에서 기기 블루투스 상태(on/off) 여부만을 확인하므로 필수 권한인 `android.permission.BLUETOOTH`제외한 나머지 권한들을 제거했습니다.

---

### ✅ To Do List

<!-- 아래에 수정 사항을 적어주세요. PR 요청 시 모두 체크되어야 합니다 -->
- [x] Android android.permission.BLUETOOTH_SCAN 선언이 필요한지 확인합니다.
- [x] 필요 여부 확인이 완료되면 삭제하거나 유지합니다.
