### PR TITLE
issue #24 fix(android8.0): 기기가 안드로이드 8.0일 경우 분기 처리

### DIFF
--- a/android/app/src/main/kotlin/onl/coconut/vault/MainActivity.kt
+++ b/android/app/src/main/kotlin/onl/coconut/vault/MainActivity.kt
@@ -20,7 +20,10 @@ class MainActivity: FlutterFragmentActivity() {
             if (call.method == "getPlatformVersion") {
                 val version = Build.VERSION.RELEASE
                 result.success(version)
-            } else if (call.method == "isDeveloperModeEnabled") {
+            } else if(call.method == "getSdkVersion"){
+                result.success(Build.VERSION.SDK_INT)
+            }
+            else if (call.method == "isDeveloperModeEnabled") {
                     result.success(isDeveloperModeEnabled())
             }
             else {

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="LaunchTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,9 @@
+import 'dart:io';
+
 import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_vault/constants/method_channel.dart';
 import 'package:coconut_vault/services/shared_preferences_service.dart';
+import 'package:coconut_vault/utils/logger.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:coconut_vault/app.dart';
@@ -15,8 +19,22 @@ void main() async {
   // Isolate 토큰 생성 및 초기화
   final RootIsolateToken rootIsolateToken = RootIsolateToken.instance!;
   BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
-  SystemChrome.setPreferredOrientations(
-      [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+  if (Platform.isAndroid) {
+    try {
+      const MethodChannel channel = MethodChannel(methodChannelOS);
+
+      final int version = await channel.invokeMethod('getSdkVersion');
+      if (version != 26) {
+        SystemChrome.setPreferredOrientations(
+            [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+      }
+    } on PlatformException catch (e) {
+      Logger.log("Failed to get platform version: '${e.message}'.");
+    }
+  } else {
+    SystemChrome.setPreferredOrientations(
+        [DeviceOrientation.portraitUp, DeviceOrientation.portraitDown]);
+  }
 
   Provider.debugCheckInvalidValueType = null;
   final dbDirectory = await getAppDocumentDirectory(paths: ['objectbox']);

--- a/lib/model/app_model.dart
+++ b/lib/model/app_model.dart
@@ -193,8 +193,13 @@ class AppModel with ChangeNotifier {
   List<String> _pinShuffleNumbers = [];
   List<String> get pinShuffleNumbers => _pinShuffleNumbers;
 
+  /// 안드로이드8 대응
+  bool _isAndroid8 = false;
+  bool get isAndroid8 => _isAndroid8;
+
   Future setInitData() async {
     await checkDeviceBiometrics();
+    _isAndroid8 = await checkIfAndroidVersion8();
     final prefs = SharedPrefsService();
     _hasSeenGuide = prefs.getBool(SharedPrefsKeys.hasShownStartGuide) == true;
     _isPinEnabled = prefs.getBool(SharedPrefsKeys.isPinEnabled) == true;
@@ -231,6 +236,25 @@ class AppModel with ChangeNotifier {
     _hasSeenGuide = true;
     SharedPrefsService().setBool(SharedPrefsKeys.hasShownStartGuide, true);
     notifyListeners();
+  }
+
+  /// 기기의 OS 버전이 안드로이드 OS 8.0 인지 체크
+  Future<bool> checkIfAndroidVersion8() async {
+    debugPrint('OS Version Check!!!');
+    if (Platform.isAndroid) {
+      try {
+        final int version = await const MethodChannel(methodChannelOS)
+            .invokeMethod('getSdkVersion');
+        if (version == 26) {
+          debugPrint('OS Version Checked! is Android 8');
+          return true;
+        }
+      } on PlatformException catch (e) {
+        Logger.log("Failed to get platform version: '${e.message}'.");
+        return false;
+      }
+    }
+    return false;
   }
 
   /// 기기의 생체인증 가능 여부 업데이트

--- a/lib/screens/pin_setting_screen.dart
+++ b/lib/screens/pin_setting_screen.dart
@@ -8,6 +8,7 @@ import 'package:coconut_vault/widgets/animated_dialog.dart';
 import 'package:coconut_vault/widgets/appbar/custom_appbar.dart';
 import 'package:coconut_vault/widgets/button/custom_buttons.dart';
 import 'package:coconut_vault/widgets/pin/pin_input_screen.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import '../widgets/custom_dialog.dart';
@@ -137,6 +138,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
 
   void _finishPinSetting() async {
     vibrateLight();
+
     showGeneralDialog(
       context: context,
       barrierDismissible: false,
@@ -164,6 +166,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
         );
       },
     );
+
     await Future.delayed(const Duration(seconds: 3));
     widget.onComplete?.call();
     await _appModel.savePin(pinConfirm);
@@ -174,7 +177,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
     }
   }
 
-  void _showDialog() {
+  void showDialog() {
     if (!_appModel.isPinEnabled) {
       Navigator.of(context).pop();
     } else {
@@ -240,7 +243,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
         isCloseIcon: !widget.greetingVisible,
         onClosePressed: step == 0
             ? () {
-                _showDialog();
+                showDialog();
               }
             : () {
                 setState(() {

--- a/lib/screens/vault_detail/export_detail_screen.dart
+++ b/lib/screens/vault_detail/export_detail_screen.dart
@@ -32,11 +32,10 @@ class _ExportDetailScreen extends State<ExportDetailScreen> {
   void _showToast() async {
     if (Platform.isAndroid) {
       try {
-        final String version =
-            await _channel.invokeMethod('getPlatformVersion');
+        final int version = await _channel.invokeMethod('getSdkVersion');
 
         // 안드로이드13 부터는 클립보드 복사 메세지가 나오기 때문에 예외 적용
-        if (int.parse(version) > 12) {
+        if (version > 31) {
           return;
         }
       } on PlatformException catch (e) {

--- a/lib/widgets/qrcode_info.dart
+++ b/lib/widgets/qrcode_info.dart
@@ -102,11 +102,10 @@ class _QRCodeInfoState extends State<QRCodeInfo> {
   void _showToast() async {
     if (Platform.isAndroid) {
       try {
-        final String version =
-            await _channel.invokeMethod('getPlatformVersion');
+        final int version = await _channel.invokeMethod('getSdkVersion');
 
         // 안드로이드13 부터는 클립보드 복사 메세지가 나오기 때문에 예외 적용
-        if (int.parse(version) > 12) {
+        if (version > 31) {
           return;
         }
       } on PlatformException catch (e) {


### PR DESCRIPTION
- 기기가 안드로이드 8.0일 경우에는 앱 실행시 SystemChrome.setPreferredOrientations 함수 실행하지 않습니다.
- 생체인증 관련 화면에서 `java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.` 이슈가 새로 발견되어, 안드로이드의 앱 테마를 다음과 같이 변경하였습니다.
- `@android:style/Theme.Light.NoTitleBar` -> `Theme.AppCompat.Light.DarkActionBar`
- MethodChannel을 통해 platformVersion을 확인하는 과정에서, 일부 버전에서는 '8.0.0' 형식으로 반환 하여 Integer를 Parse 하는 과정에서 충돌이 발생하였습니다. platformVersion이 아닌 sdkVersion을 통해 Integer 형식으로 가져오도록 통합하였습니다.