### PR TITLE
issue #28 fix(loadVault): remove unnecessary load logic

### DIFF
--- a/lib/model/vault_model.dart
+++ b/lib/model/vault_model.dart
@@ -52,6 +52,8 @@ class VaultModel extends ChangeNotifier {
   // double _vaultListLoadingProgress = 0.0;
   // double get vaultListLoadingProgress => _vaultListLoadingProgress;
   // static int itemSize = 0;
+  bool _vaultInitialized = false;
+  bool get vaultInitialized => _vaultInitialized;
 
   // addVault
   bool _isAddVaultCompleted = false;
@@ -193,6 +195,8 @@ class VaultModel extends ChangeNotifier {
       } else {
         throw Exception("IsolateHandler not initialized");
       }
+
+      _vaultInitialized = true;
     } catch (e) {
       Logger.log('[loadVaultList] Exception : ${e.toString()}');
     } finally {

--- a/lib/vault_list_tab.dart
+++ b/lib/vault_list_tab.dart
@@ -45,15 +45,19 @@ class _VaultListTabState extends State<VaultListTab>
     super.initState();
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (widget.reload == null || widget.reload == true) {
-        _vaultModel.loadVaultList();
-      }
-
       // 초기화 이후 홈화면 진입시 설정창 노출
       if (_appModel.isResetVault) {
         MyBottomSheet.showBottomSheet_90(
             context: context, child: const SettingsScreen());
         _appModel.offResetVault();
+      }
+      // 지갑 추가, 지갑 삭제, 서명완료 후 불필요하게 loadVaultList() 호출되는 것을 막음
+      if (_vaultModel.vaultInitialized) {
+        return;
+      }
+
+      if (widget.reload == null || widget.reload == true) {
+        _vaultModel.loadVaultList();
       }
     });
   }


### PR DESCRIPTION
vault_list_tab.dart의 initState에 loadVaultList() 호출하는 부분이 다음 상황에서 불필요하게 호출되는 것을 막았습니다.

1. 서명 완료 후 홈화면 돌아왔을 때
2. 지갑 추가 후 홈화면 돌아왔을 때