### PR TITLE
[124] 앱 진입 시 화면 이동 통합 테스트 작성

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -54,6 +54,13 @@ Flutter Test를 클릭해주고, Test File 경로를 지정합니다. Additional
    - 파일 저장 및 삭제 기능 검증
    - 보안 스토리지 연동 검증
 
+3. `app_flow_test.dart`
+   - 앱 첫 시작 시 Tutorial 화면으로 진입하는지 확인하는 통합 테스트
+   - 추가된 지갑이 있을 때 PinCheckScreen -> VaultListScreen으로 진입하는지 확인하는 통합 테스트
+   - 추가된 지갑이 없을 때 PinCheckScreen을 거치지 않고 바로 VaultListScreen으로 진입하는지 확인하는 통합 테스트
+   - 복원 파일이 존재하고 앱 업데이트가 완료됐을 때 PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트
+   - 복원 파일이 존재하고 앱 업데이트가 안됐을 때 RestorationInfoScreen -> PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트
+
 ## 주의사항
 
 - 테스트는 실제 디바이스의 저장소와 보안 기능을 사용합니다.

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -55,11 +55,11 @@ Flutter Test를 클릭해주고, Test File 경로를 지정합니다. Additional
    - 보안 스토리지 연동 검증
 
 3. `app_flow_test.dart`
-   - 앱 첫 시작 시 Tutorial 화면으로 진입하는지 확인하는 통합 테스트
-   - 추가된 지갑이 있을 때 PinCheckScreen -> VaultListScreen으로 진입하는지 확인하는 통합 테스트
-   - 추가된 지갑이 없을 때 PinCheckScreen을 거치지 않고 바로 VaultListScreen으로 진입하는지 확인하는 통합 테스트
-   - 복원 파일이 존재하고 앱 업데이트가 완료됐을 때 PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트
-   - 복원 파일이 존재하고 앱 업데이트가 안됐을 때 RestorationInfoScreen -> PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트
+   - 앱 첫 시작 시 Tutorial 화면으로 진입하는 통합테스트
+   - 추가된 지갑이 있을 때 PinCheckScreen -> VaultListScreen으로 진입하는 통합테스트
+   - 추가된 지갑이 없을 때 PinCheckScreen을 거치지 않고 바로 VaultListScreen으로 진입하는 통합테스트
+   - 복원 파일이 존재하고 앱 업데이트가 완료됐을 때 PinCheckScreen -> VaultListRestorationScreen -> VaultListScreen으로 진입하는 통합테스트
+   - 복원 파일이 존재하고 앱 업데이트가 안됐을 때 RestorationInfoScreen -> PinCheckScreen -> VaultListRestorationScreen -> VaultList으로 진입하는 통합테스트
 
 ## 주의사항
 

--- a/integration_test/app_flow_test.dart
+++ b/integration_test/app_flow_test.dart
@@ -40,21 +40,19 @@ void main() {
 
   group('AppFlow Integration Tests', () {
     // 1. 앱 첫 시작 시 Tutorial 화면으로 진입하는 통합테스트
-    testWidgets('You have to go to TutorialScreen at first time',
-        (tester) async {
+    testWidgets('You have to go to TutorialScreen at first time', (tester) async {
       app.main();
       await tester.pumpAndSettle();
 
       // Check TutorialScreen
       final Finder tutorialScreen = find.byType(TutorialScreen);
       await waitForWidget(tester, tutorialScreen,
-          timeoutMessage: 'tutorialScreen not found after 10 seconds');
+          timeoutMessage: 'tutorialScreen not found after 60 seconds');
       await tester.pumpAndSettle();
     });
 
     // 2. 추가된 지갑이 있을 때 PinCheckScreen -> VaultListScreen으로 진입하는 통합테스트
-    testWidgets(
-        'You have to go to PinCheckScreen and then VaultListScreen when you have wallets',
+    testWidgets('You have to go to PinCheckScreen and then VaultListScreen when you have wallets',
         (tester) async {
       await removeStartGuideFlag();
       await savePinCode("0000");
@@ -65,7 +63,7 @@ void main() {
       // Check PinCheckScreen
       final Finder pinCheckScreen = find.byType(PinCheckScreen);
       await waitForWidget(tester, pinCheckScreen,
-          timeoutMessage: 'pinCheckScreen not found after 10 seconds');
+          timeoutMessage: 'pinCheckScreen not found after 60 seconds');
       await tester.pumpAndSettle();
 
       // Input Password 0000
@@ -78,13 +76,12 @@ void main() {
       // Check VaultListScreen
       final Finder vaultListScreen = find.byType(VaultListScreen);
       await waitForWidget(tester, vaultListScreen,
-          timeoutMessage: 'VaultListScreen not found after 10 seconds');
+          timeoutMessage: 'VaultListScreen not found after 60 seconds');
       await tester.pumpAndSettle();
     });
 
     // 3. 추가된 지갑이 없을 때 PinCheckScreen을 거치지 않고 바로 VaultListScreen으로 진입하는 통합테스트
-    testWidgets(
-        'You have to go to VaultListScreen without PinCode Check when you have no wallets',
+    testWidgets('You have to go to VaultListScreen without PinCode Check when you have no wallets',
         (tester) async {
       await removeStartGuideFlag();
       app.main();
@@ -93,7 +90,7 @@ void main() {
       // Check VaultListScreen
       final Finder vaultListScreen = find.byType(VaultListScreen);
       await waitForWidget(tester, vaultListScreen,
-          timeoutMessage: 'VaultListScreen not found after 10 seconds');
+          timeoutMessage: 'VaultListScreen not found after 60 seconds');
       await tester.pumpAndSettle();
     });
   });
@@ -114,7 +111,7 @@ void main() {
       // Check PinCheckScreen
       final Finder pinCheckScreen = find.byType(PinCheckScreen);
       await waitForWidget(tester, pinCheckScreen,
-          timeoutMessage: 'pinCheckScreen not found after 10 seconds');
+          timeoutMessage: 'pinCheckScreen not found after 60 seconds');
       await tester.pumpAndSettle();
 
       // Input Password 0000
@@ -125,22 +122,19 @@ void main() {
       await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
 
       // Check vaultListRestorationScreen
-      final Finder vaultListRestorationScreen =
-          find.byType(VaultListRestorationScreen);
+      final Finder vaultListRestorationScreen = find.byType(VaultListRestorationScreen);
       await waitForWidget(tester, vaultListRestorationScreen,
-          timeoutMessage:
-              'vaultListRestorationScreen not found after 10 seconds');
+          timeoutMessage: 'vaultListRestorationScreen not found after 60 seconds');
       await tester.pumpAndSettle();
 
       // Wait for restoration
-      final Finder startVaultText =
-          find.text(t.vault_list_restoration.start_vault);
+      final Finder startVaultText = find.text(t.vault_list_restoration.start_vault);
       await waitForWidgetAndTap(tester, startVaultText, "startVaultText");
 
       // Check VaultListScreen
       final Finder vaultListScreen = find.byType(VaultListScreen);
       await waitForWidget(tester, vaultListScreen,
-          timeoutMessage: 'VaultListScreen not found after 10 seconds');
+          timeoutMessage: 'VaultListScreen not found after 60 seconds');
       await tester.pumpAndSettle();
     });
 
@@ -160,7 +154,7 @@ void main() {
       // Check RestorationInfoScreen
       final Finder restorationInfoScreen = find.byType(RestorationInfoScreen);
       await waitForWidget(tester, restorationInfoScreen,
-          timeoutMessage: 'restorationInfoScreen not found after 10 seconds');
+          timeoutMessage: 'restorationInfoScreen not found after 60 seconds');
       await tester.pumpAndSettle();
 
       // Click CoconutButton
@@ -170,7 +164,7 @@ void main() {
       // Click PinCheckScreen
       final Finder pinCheckScreen = find.byType(PinCheckScreen);
       await waitForWidget(tester, pinCheckScreen,
-          timeoutMessage: 'pinCheckScreen not found after 10 seconds');
+          timeoutMessage: 'pinCheckScreen not found after 60 seconds');
       await tester.pumpAndSettle();
 
       // Input Password 0000
@@ -181,21 +175,18 @@ void main() {
       await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
 
       // Check VaultListRestorationScreen
-      final Finder vaultListRestorationScreen =
-          find.byType(VaultListRestorationScreen);
+      final Finder vaultListRestorationScreen = find.byType(VaultListRestorationScreen);
       await waitForWidget(tester, vaultListRestorationScreen,
-          timeoutMessage:
-              'vaultListRestorationScreen not found after 10 seconds');
+          timeoutMessage: 'vaultListRestorationScreen not found after 60 seconds');
 
       // Wait for restoration
-      final Finder startVaultText =
-          find.text(t.vault_list_restoration.start_vault);
+      final Finder startVaultText = find.text(t.vault_list_restoration.start_vault);
       await waitForWidgetAndTap(tester, startVaultText, "startVaultText");
 
       // Check VaultListScreen
       final Finder vaultListScreen = find.byType(VaultListScreen);
       await waitForWidget(tester, vaultListScreen,
-          timeoutMessage: 'VaultListScreen not found after 10 seconds');
+          timeoutMessage: 'VaultListScreen not found after 60 seconds');
       await tester.pumpAndSettle();
     });
   });

--- a/integration_test/app_flow_test.dart
+++ b/integration_test/app_flow_test.dart
@@ -39,7 +39,7 @@ void main() {
   });
 
   group('AppFlow Integration Tests', () {
-    // 1. 앱 첫 시작 시 Tutorial 화면으로 진입하는지 확인하는 통합 테스트
+    // 1. 앱 첫 시작 시 Tutorial 화면으로 진입하는 통합테스트
     testWidgets('You have to go to TutorialScreen at first time',
         (tester) async {
       app.main();
@@ -52,7 +52,7 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    // 2. 추가된 지갑이 있을 때 PinCheckScreen -> VaultListScreen으로 진입하는지 확인하는 통합 테스트
+    // 2. 추가된 지갑이 있을 때 PinCheckScreen -> VaultListScreen으로 진입하는 통합테스트
     testWidgets(
         'You have to go to PinCheckScreen and then VaultListScreen when you have wallets',
         (tester) async {
@@ -82,7 +82,7 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    // 3. 추가된 지갑이 없을 때 PinCheckScreen을 거치지 않고 바로 VaultListScreen으로 진입하는지 확인하는 통합 테스트
+    // 3. 추가된 지갑이 없을 때 PinCheckScreen을 거치지 않고 바로 VaultListScreen으로 진입하는 통합테스트
     testWidgets(
         'You have to go to VaultListScreen without PinCode Check when you have no wallets',
         (tester) async {
@@ -96,8 +96,10 @@ void main() {
           timeoutMessage: 'VaultListScreen not found after 10 seconds');
       await tester.pumpAndSettle();
     });
+  });
 
-    // 4. 복원 파일이 존재하고 앱 업데이트가 완료됐을 때 PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트
+  group('AppFlow Integration Tests: BackUp File', () {
+    // 4. 복원 파일이 존재하고 앱 업데이트가 완료됐을 때 PinCheckScreen -> VaultListRestorationScreen -> VaultListScreen으로 진입하는 통합테스트
     testWidgets(
         '[UPDATED] You have to go to PinCheckScreen and then VaultListRestorationScreen when you have backup file',
         (tester) async {
@@ -131,14 +133,18 @@ void main() {
       await tester.pumpAndSettle();
 
       // Wait for restoration
-      final Finder completedText =
-          find.text(t.vault_list_restoration.completed_title);
-      await waitForWidget(tester, completedText,
-          timeoutMessage: 'completedText not found after 10 seconds');
+      final Finder startVaultText =
+          find.text(t.vault_list_restoration.start_vault);
+      await waitForWidgetAndTap(tester, startVaultText, "startVaultText");
+
+      // Check VaultListScreen
+      final Finder vaultListScreen = find.byType(VaultListScreen);
+      await waitForWidget(tester, vaultListScreen,
+          timeoutMessage: 'VaultListScreen not found after 10 seconds');
       await tester.pumpAndSettle();
     });
 
-    // 5. 복원 파일이 존재하고 앱 업데이트가 안됐을 때 RestorationInfoScreen -> PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트
+    // 5. 복원 파일이 존재하고 앱 업데이트가 안됐을 때 RestorationInfoScreen -> PinCheckScreen -> VaultListRestorationScreen -> VaultList으로 진입하는 통합 테스트
     testWidgets(
         '[NOT UPDATED] You have to go to RestorationInfoScreen and then pinCheck, VaultListRestorationScreen when you have backup file',
         (tester) async {
@@ -182,10 +188,14 @@ void main() {
               'vaultListRestorationScreen not found after 10 seconds');
 
       // Wait for restoration
-      final Finder completedText =
-          find.text(t.vault_list_restoration.completed_title);
-      await waitForWidget(tester, completedText,
-          timeoutMessage: 'completedText not found after 10 seconds');
+      final Finder startVaultText =
+          find.text(t.vault_list_restoration.start_vault);
+      await waitForWidgetAndTap(tester, startVaultText, "startVaultText");
+
+      // Check VaultListScreen
+      final Finder vaultListScreen = find.byType(VaultListScreen);
+      await waitForWidget(tester, vaultListScreen,
+          timeoutMessage: 'VaultListScreen not found after 10 seconds');
       await tester.pumpAndSettle();
     });
   });

--- a/integration_test/app_flow_test.dart
+++ b/integration_test/app_flow_test.dart
@@ -1,0 +1,192 @@
+import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_vault/localization/strings.g.dart';
+import 'package:coconut_vault/managers/wallet_list_manager.dart';
+import 'package:coconut_vault/repository/secure_storage_repository.dart';
+import 'package:coconut_vault/repository/shared_preferences_repository.dart';
+import 'package:coconut_vault/screens/app_update/restoration_info_screen.dart';
+import 'package:coconut_vault/screens/app_update/vault_list_restoration_screen.dart';
+import 'package:coconut_vault/screens/common/pin_check_screen.dart';
+import 'package:coconut_vault/screens/home/tutorial_screen.dart';
+import 'package:coconut_vault/screens/home/vault_list_screen.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:coconut_vault/utils/coconut/update_preparation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:coconut_vault/main.dart' as app;
+
+import 'integration_test_utils.dart';
+
+/// 백업 데이터 암호화/복호화 및 파일 저장 기능 테스트
+///
+/// 실행 명령어:
+/// ```bash
+/// flutter test integration_test/app_flow_test.dart --flavor regtest
+/// ```
+///
+/// 자세한 내용은 README.md 참고
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() async {
+    final prefs = SharedPrefsRepository();
+    await prefs.init();
+    await prefs.clearSharedPref();
+    await SecureStorageRepository().deleteAll();
+    await WalletListManager().loadVaultListJsonArrayString();
+  });
+
+  tearDown(() async {
+    await UpdatePreparation.clearUpdatePreparationStorage();
+  });
+
+  group('AppFlow Integration Tests', () {
+    // 1. 앱 첫 시작 시 Tutorial 화면으로 진입하는지 확인하는 통합 테스트
+    testWidgets('You have to go to TutorialScreen at first time',
+        (tester) async {
+      app.main();
+      await tester.pumpAndSettle();
+
+      // Check TutorialScreen
+      final Finder tutorialScreen = find.byType(TutorialScreen);
+      await waitForWidget(tester, tutorialScreen,
+          timeoutMessage: 'tutorialScreen not found after 10 seconds');
+      await tester.pumpAndSettle();
+    });
+
+    // 2. 추가된 지갑이 있을 때 PinCheckScreen -> VaultListScreen으로 진입하는지 확인하는 통합 테스트
+    testWidgets(
+        'You have to go to PinCheckScreen and then VaultListScreen when you have wallets',
+        (tester) async {
+      await removeStartGuideFlag();
+      await savePinCode("0000");
+      await addWallets();
+      app.main();
+      await tester.pumpAndSettle();
+
+      // Check PinCheckScreen
+      final Finder pinCheckScreen = find.byType(PinCheckScreen);
+      await waitForWidget(tester, pinCheckScreen,
+          timeoutMessage: 'pinCheckScreen not found after 10 seconds');
+      await tester.pumpAndSettle();
+
+      // Input Password 0000
+      final Finder zeroButton = find.text('0');
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+
+      // Check VaultListScreen
+      final Finder vaultListScreen = find.byType(VaultListScreen);
+      await waitForWidget(tester, vaultListScreen,
+          timeoutMessage: 'VaultListScreen not found after 10 seconds');
+      await tester.pumpAndSettle();
+    });
+
+    // 3. 추가된 지갑이 없을 때 PinCheckScreen을 거치지 않고 바로 VaultListScreen으로 진입하는지 확인하는 통합 테스트
+    testWidgets(
+        'You have to go to VaultListScreen without PinCode Check when you have no wallets',
+        (tester) async {
+      await removeStartGuideFlag();
+      app.main();
+      await tester.pumpAndSettle();
+
+      // Check VaultListScreen
+      final Finder vaultListScreen = find.byType(VaultListScreen);
+      await waitForWidget(tester, vaultListScreen,
+          timeoutMessage: 'VaultListScreen not found after 10 seconds');
+      await tester.pumpAndSettle();
+    });
+
+    // 4. 복원 파일이 존재하고 앱 업데이트가 완료됐을 때 PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트
+    testWidgets(
+        '[UPDATED] You have to go to PinCheckScreen and then VaultListRestorationScreen when you have backup file',
+        (tester) async {
+      await removeStartGuideFlag();
+      await savePinCode("0000");
+      await saveBackupData();
+      await saveAppVersion("1.0.0");
+
+      app.main();
+      await tester.pumpAndSettle();
+
+      // Check PinCheckScreen
+      final Finder pinCheckScreen = find.byType(PinCheckScreen);
+      await waitForWidget(tester, pinCheckScreen,
+          timeoutMessage: 'pinCheckScreen not found after 10 seconds');
+      await tester.pumpAndSettle();
+
+      // Input Password 0000
+      final Finder zeroButton = find.text('0');
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+
+      // Check vaultListRestorationScreen
+      final Finder vaultListRestorationScreen =
+          find.byType(VaultListRestorationScreen);
+      await waitForWidget(tester, vaultListRestorationScreen,
+          timeoutMessage:
+              'vaultListRestorationScreen not found after 10 seconds');
+      await tester.pumpAndSettle();
+
+      // Wait for restoration
+      final Finder completedText =
+          find.text(t.vault_list_restoration.completed_title);
+      await waitForWidget(tester, completedText,
+          timeoutMessage: 'completedText not found after 10 seconds');
+      await tester.pumpAndSettle();
+    });
+
+    // 5. 복원 파일이 존재하고 앱 업데이트가 안됐을 때 RestorationInfoScreen -> PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트
+    testWidgets(
+        '[NOT UPDATED] You have to go to RestorationInfoScreen and then pinCheck, VaultListRestorationScreen when you have backup file',
+        (tester) async {
+      await removeStartGuideFlag();
+      await savePinCode("0000");
+      await saveBackupData();
+      final PackageInfo packageInfo = await PackageInfo.fromPlatform();
+      await saveAppVersion(packageInfo.version.split('-').first);
+
+      app.main();
+      await tester.pumpAndSettle();
+
+      // Check RestorationInfoScreen
+      final Finder restorationInfoScreen = find.byType(RestorationInfoScreen);
+      await waitForWidget(tester, restorationInfoScreen,
+          timeoutMessage: 'restorationInfoScreen not found after 10 seconds');
+      await tester.pumpAndSettle();
+
+      // Click CoconutButton
+      final Finder coconutButton = find.byType(CoconutButton);
+      await waitForWidgetAndTap(tester, coconutButton, "coconutButton");
+
+      // Click PinCheckScreen
+      final Finder pinCheckScreen = find.byType(PinCheckScreen);
+      await waitForWidget(tester, pinCheckScreen,
+          timeoutMessage: 'pinCheckScreen not found after 10 seconds');
+      await tester.pumpAndSettle();
+
+      // Input Password 0000
+      final Finder zeroButton = find.text('0');
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+      await waitForWidgetAndTap(tester, zeroButton, "zeroButton");
+
+      // Check VaultListRestorationScreen
+      final Finder vaultListRestorationScreen =
+          find.byType(VaultListRestorationScreen);
+      await waitForWidget(tester, vaultListRestorationScreen,
+          timeoutMessage:
+              'vaultListRestorationScreen not found after 10 seconds');
+
+      // Wait for restoration
+      final Finder completedText =
+          find.text(t.vault_list_restoration.completed_title);
+      await waitForWidget(tester, completedText,
+          timeoutMessage: 'completedText not found after 10 seconds');
+      await tester.pumpAndSettle();
+    });
+  });
+}

--- a/integration_test/integration_test_utils.dart
+++ b/integration_test/integration_test_utils.dart
@@ -1,4 +1,19 @@
+import 'dart:convert';
+
+import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_vault/constants/secure_storage_keys.dart';
+import 'package:coconut_vault/constants/shared_preferences_keys.dart';
+import 'package:coconut_vault/managers/wallet_list_manager.dart';
+import 'package:coconut_vault/model/multisig/multisig_signer.dart';
+import 'package:coconut_vault/model/multisig/multisig_wallet.dart';
+import 'package:coconut_vault/model/single_sig/single_sig_wallet.dart';
+import 'package:coconut_vault/providers/wallet_provider.dart';
+import 'package:coconut_vault/repository/secure_storage_repository.dart';
+import 'package:coconut_vault/repository/shared_preferences_repository.dart';
+import 'package:coconut_vault/utils/coconut/update_preparation.dart';
+import 'package:coconut_vault/utils/hash_util.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Waits for a widget to appear on the screen with a timeout (100초).
 /// Returns true if the widget was found, false if it timed out.
@@ -23,4 +38,178 @@ Future<void> waitForWidgetAndTap(
       timeoutSeconds: timeoutSeconds);
   await tester.tap(element);
   await tester.pumpAndSettle();
+}
+
+Future<void> removeStartGuideFlag() async {
+  final prefs = await SharedPreferences.getInstance();
+  prefs.setBool(SharedPrefsKeys.hasShownStartGuide, true);
+}
+
+Future<void> savePinCode(String pinCode) async {
+  final SecureStorageRepository storageService = SecureStorageRepository();
+  final SharedPreferences sharedPreferences =
+      await SharedPreferences.getInstance();
+  await storageService.write(
+      key: SecureStorageKeys.kVaultPin, value: hashString(pinCode));
+  await sharedPreferences.setBool(SharedPrefsKeys.isPinEnabled, true);
+}
+
+Future<void> saveAppVersion(String version) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString(SharedPrefsKeys.kAppVersion, version);
+}
+
+Future<void> saveBackupData() async {
+  var backupData = [
+    {
+      "id": 1,
+      "name": "Test Wallet1",
+      "colorIndex": 0,
+      "iconIndex": 0,
+      "vaultType": "singleSignature",
+      "secret":
+          "thank split shrimp error own spirit slow glow act evidence globe slight",
+      "passphrase": "",
+      "linkedMultisigInfo": {"2": 0},
+      "signerBsms":
+          "BSMS 1.0\n00\n[B928B226/48'/1'/0'/2']Vpub5mHQNgTYgzTpc85RnEQkA4yA5zC2vX4uDS3w7H8B6RKkNnD93Yb3QinD8NBa9oQrcg2NwTGjh3hKyToUn7PSPZcVyiSbbEJCkFcN8ub6aRM\nTest Wallet1"
+    },
+    {
+      "id": 2,
+      "name": "Test Wallet2",
+      "colorIndex": 0,
+      "iconIndex": 0,
+      "vaultType": "multiSignature",
+      "signers": [
+        {
+          "id": 0,
+          "innerVaultId": 1,
+          "name": "Inside Wallet",
+          "iconIndex": 0,
+          "colorIndex": 0,
+          "signerBsms":
+              "BSMS 1.0\n00\n[E0C42931/48'/1'/0'/2']Vpub5nNFgHQhQCGEaWtoLrnzWjDvngmwS9A8qT8g1tjkWrbvYwLGrcYupy8jFXmJqyFd9u6aeRTvuLKMrGZ8jdfbarYvLS8rK4Z8Qp5uvKjLTNt\nttt\n",
+          "memo": null,
+          "keyStore":
+              "{\"fingerprint\":\"E0C42931\",\"hdWallet\":\"{\\\"publicKey\\\":\\\"02b4738642a07009443ff12a85b2f4a7806291de4c2a481fb2c0432a8468badf6c\\\",\\\"chainCode\\\":\\\"c7323611efb46993ed234e3028fdfd5c9d2c93b74cda8572c2599aa2a70d13a3\\\"}\",\"extendedPublicKey\":\"Vpub5nNFgHQhQCGEaWtoLrnzWjDvngmwS9A8qT8g1tjkWrbvYwLGrcYupy8jFXmJqyFd9u6aeRTvuLKMrGZ8jdfbarYvLS8rK4Z8Qp5uvKjLTNt\"}"
+        },
+        {
+          "id": 0,
+          "innerVaultId": null,
+          "name": "여여려",
+          "iconIndex": null,
+          "colorIndex": null,
+          "signerBsms":
+              "BSMS 1.0\n00\n[858FA201/48'/1'/0'/2']Vpub5ncWX3M18jrGdytgNZfayhkzj37RpXHH5k11QsEC4BBJZga64W92KFDVg8CRoEyBAm4eZqXUTKEgx991ri14aWkBhAsgjak5pMHa8wjYirr\n여여려\n",
+          "memo": "memo test",
+          "keyStore":
+              "{\"fingerprint\":\"858FA201\",\"hdWallet\":\"{\\\"publicKey\\\":\\\"03ae52f4371a5b32c87de3eb446cb790bb382f7f24f03d3780707c536f66e8ac55\\\",\\\"chainCode\\\":\\\"cd7f31d5c34c19359454ae5074a96ff556f9a2dcfca5adef1130a9cb68d04d8e\\\"}\",\"extendedPublicKey\":\"Vpub5ncWX3M18jrGdytgNZfayhkzj37RpXHH5k11QsEC4BBJZga64W92KFDVg8CRoEyBAm4eZqXUTKEgx991ri14aWkBhAsgjak5pMHa8wjYirr\"}"
+        }
+      ],
+      "coordinatorBsms":
+          "BSMS 1.0\nwsh(sortedmulti(2,[E0C42931/48'/1'/0'/2']Vpub5nNFgHQhQCGEaWtoLrnzWjDvngmwS9A8qT8g1tjkWrbvYwLGrcYupy8jFXmJqyFd9u6aeRTvuLKMrGZ8jdfbarYvLS8rK4Z8Qp5uvKjLTNt/<0;1>/*,[858FA201/48'/1'/0'/2']Vpub5ncWX3M18jrGdytgNZfayhkzj37RpXHH5k11QsEC4BBJZga64W92KFDVg8CRoEyBAm4eZqXUTKEgx991ri14aWkBhAsgjak5pMHa8wjYirr/<0;1>/*))#9zfcfeny\n/0/*,/1/*\nbcrt1quajap24pe8z07dshjtln7lmrz4cree8y444ku8wgfugqnnn68qzqggqd52",
+      "requiredSignatureCount": 2
+    }
+  ];
+
+  await UpdatePreparation.encryptAndSave(data: jsonEncode(backupData));
+}
+
+Future<int> addSingleSigWallets({WalletProvider? walletProvider}) async {
+  final singleSig2 = SinglesigWallet(
+    2,
+    "New Wallet3",
+    0,
+    0,
+    "primary exotic display destroy wrap zoo among scan length despair lend yard",
+    '',
+  );
+
+  final singleSig3 = SinglesigWallet(
+    3,
+    "Test Wallet4",
+    0,
+    0,
+    "dwarf aim crash town chalk device bulb simple space draft ball canoe",
+    '',
+  );
+
+  if (walletProvider != null) {
+    await walletProvider.addSingleSigVault(singleSig2);
+    await walletProvider.addSingleSigVault(singleSig3);
+  } else {
+    WalletListManager walletListManager = WalletListManager();
+    await walletListManager.addSinglesigWallet(singleSig2);
+    await walletListManager.addSinglesigWallet(singleSig3);
+    await SharedPrefsRepository().setInt(
+        SharedPrefsKeys.vaultListLength, walletListManager.vaultList.length);
+  }
+  return 2;
+}
+
+Future<int> addWallets({WalletProvider? walletProvider}) async {
+  // single sig wallet
+  final singleSig = SinglesigWallet(
+    1,
+    "Test Wallet1",
+    0,
+    0,
+    "thank split shrimp error own spirit slow glow act evidence globe slight",
+    '',
+  );
+
+  // multisig wallet
+  String internalWalletBsms = '''
+BSMS 1.0
+00
+[E0C42931/48'/1'/0'/2']Vpub5nNFgHQhQCGEaWtoLrnzWjDvngmwS9A8qT8g1tjkWrbvYwLGrcYupy8jFXmJqyFd9u6aeRTvuLKMrGZ8jdfbarYvLS8rK4Z8Qp5uvKjLTNt
+ttt
+''';
+  String outsideWalletBsms = '''
+BSMS 1.0
+00
+[858FA201/48'/1'/0'/2']Vpub5ncWX3M18jrGdytgNZfayhkzj37RpXHH5k11QsEC4BBJZga64W92KFDVg8CRoEyBAm4eZqXUTKEgx991ri14aWkBhAsgjak5pMHa8wjYirr
+여여려
+''';
+  List<KeyStore> keyStores = [
+    KeyStore.fromSignerBsms(internalWalletBsms),
+    KeyStore.fromSignerBsms(outsideWalletBsms)
+  ];
+  List<MultisigSigner> signers = [
+    MultisigSigner(
+      id: 0,
+      innerVaultId: 1,
+      name: "Inside Wallet",
+      iconIndex: 0,
+      colorIndex: 0,
+      signerBsms: internalWalletBsms,
+      keyStore: keyStores[0],
+    ),
+    MultisigSigner(
+      id: 0,
+      signerBsms: outsideWalletBsms,
+      name: outsideWalletBsms.split('\n')[3],
+      memo: 'memo test',
+      keyStore: keyStores[1],
+    ),
+  ];
+
+  if (walletProvider != null) {
+    await walletProvider.addSingleSigVault(singleSig);
+    await walletProvider.addMultisigVault(
+      "Test Wallet2",
+      0,
+      0,
+      signers,
+      2,
+    );
+  } else {
+    WalletListManager walletListManager = WalletListManager();
+    await walletListManager.addSinglesigWallet(singleSig);
+    await walletListManager.addMultisigWallet(
+        MultisigWallet(null, "Test Wallet2", 0, 0, signers, 2));
+    await SharedPrefsRepository().setInt(
+        SharedPrefsKeys.vaultListLength, walletListManager.vaultList.length);
+  }
+  return 2;
 }

--- a/integration_test/update_preparation_test.dart
+++ b/integration_test/update_preparation_test.dart
@@ -1,10 +1,7 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
-import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_vault/enums/wallet_enums.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/model/common/vault_list_item_base.dart';
-import 'package:coconut_vault/model/multisig/multisig_signer.dart';
-import 'package:coconut_vault/model/single_sig/single_sig_wallet.dart';
 import 'package:coconut_vault/providers/auth_provider.dart';
 import 'package:coconut_vault/providers/view_model/app_update_preparation_view_model.dart';
 import 'package:coconut_vault/providers/wallet_provider.dart';
@@ -15,8 +12,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:coconut_vault/utils/coconut/update_preparation.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:coconut_vault/main.dart' as app;
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'integration_test_utils.dart';
 
@@ -42,6 +39,7 @@ void main() {
   });
 
   group('UpdatePreparation Integration Tests', () {
+    // 업데이트 준비 프로세스에서 싱글시그니처 월렛의 니모닉을 검증합니다.
     testWidgets('Mnemonic check test', (tester) async {
       await skipScreensUntilVaultList(tester);
 
@@ -52,18 +50,18 @@ void main() {
       );
       await authProvider.savePin("0000");
 
-      // add wallets
+      // Add Wallets on VaultListScreen
       final walletProvider = Provider.of<WalletProvider>(
         tester.element(find.byType(CupertinoApp)),
         listen: false,
       );
-      int count = await addWallets(walletProvider, tester);
+      int count = await addWallets(walletProvider: walletProvider);
       expect(walletProvider.vaultList.length, count);
 
-      count += await addSingleSigWallets(walletProvider, tester);
+      count += await addSingleSigWallets(walletProvider: walletProvider);
       expect(walletProvider.vaultList.length, count);
 
-      // vault list screen to update preparation screen
+      // VaultListScreen to UpdatePreparationScreen
       await showUpdatePreparationScreen(tester);
 
       final updatePreparationProvider =
@@ -74,13 +72,15 @@ void main() {
 
       List<VaultListItemBase> singleSignVaults =
           walletProvider.getVaultsByWalletType(WalletType.singleSignature);
+      // Check if mnemonic is loaded
       expect(updatePreparationProvider.isMnemonicLoaded, true);
 
-      // Check if Logic works correctly (text, index)
+      // Find TextInput for mnemonic validation
       final Finder textInput = find.byType(CoconutTextField);
       await waitForWidgetAndTap(tester, textInput, "textInput");
 
       for (int i = 0; i < singleSignVaults.length; i++) {
+        // Load vault's mnemonicList
         List<String> vaultMnemonicList = await walletProvider
             .getSecret(singleSignVaults[i].id)
             .then((secret) => secret.mnemonic.split(' '));
@@ -90,15 +90,17 @@ void main() {
           n: updatePreparationProvider.mnemonicWordIndex,
         );
 
+        // Check title Text
         final Finder titleText = find.text(title);
         expect(titleText, findsOneWidget);
 
+        // Input mnemonic to TextInput
         await tester.enterText(textInput,
             vaultMnemonicList[updatePreparationProvider.mnemonicWordIndex - 1]);
         await tester.pumpAndSettle();
       }
 
-      // Check if Logic finished correctly
+      // Check if Logic is finished
       expect(updatePreparationProvider.isMnemonicValidationFinished, true);
     });
 
@@ -109,7 +111,7 @@ void main() {
         tester.element(find.byType(CupertinoApp)),
         listen: false,
       );
-      int count = await addWallets(walletProvider, tester);
+      int count = await addWallets(walletProvider: walletProvider);
       expect(walletProvider.vaultList.length, count);
       final backupData = await walletProvider.createBackupData();
       expect(backupData, isNotEmpty);
@@ -190,90 +192,4 @@ Future<void> showUpdatePreparationScreen(WidgetTester tester) async {
   // Click confirm text on update preparation screen
   final Finder confirmText = find.text(t.confirm);
   await waitForWidgetAndTap(tester, confirmText, "confirmText");
-}
-
-Future<int> addSingleSigWallets(
-    WalletProvider walletProvider, WidgetTester tester) async {
-  final singleSig2 = SinglesigWallet(
-    2,
-    "New Wallet3",
-    0,
-    0,
-    "primary exotic display destroy wrap zoo among scan length despair lend yard",
-    '',
-  );
-
-  final singleSig3 = SinglesigWallet(
-    3,
-    "Test Wallet4",
-    0,
-    0,
-    "dwarf aim crash town chalk device bulb simple space draft ball canoe",
-    '',
-  );
-
-  await walletProvider.addSingleSigVault(singleSig2);
-  await walletProvider.addSingleSigVault(singleSig3);
-  return 2;
-}
-
-Future<int> addWallets(
-    WalletProvider walletProvider, WidgetTester tester) async {
-  // single sig wallet
-  final singleSig = SinglesigWallet(
-    1,
-    "Test Wallet1",
-    0,
-    0,
-    "thank split shrimp error own spirit slow glow act evidence globe slight",
-    '',
-  );
-
-  await walletProvider.addSingleSigVault(singleSig);
-
-  // multisig wallet
-  String internalWalletBsms = '''
-BSMS 1.0
-00
-[E0C42931/48'/1'/0'/2']Vpub5nNFgHQhQCGEaWtoLrnzWjDvngmwS9A8qT8g1tjkWrbvYwLGrcYupy8jFXmJqyFd9u6aeRTvuLKMrGZ8jdfbarYvLS8rK4Z8Qp5uvKjLTNt
-ttt
-''';
-  String outsideWalletBsms = '''
-BSMS 1.0
-00
-[858FA201/48'/1'/0'/2']Vpub5ncWX3M18jrGdytgNZfayhkzj37RpXHH5k11QsEC4BBJZga64W92KFDVg8CRoEyBAm4eZqXUTKEgx991ri14aWkBhAsgjak5pMHa8wjYirr
-여여려
-''';
-  List<KeyStore> keyStores = [
-    KeyStore.fromSignerBsms(internalWalletBsms),
-    KeyStore.fromSignerBsms(outsideWalletBsms)
-  ];
-  List<MultisigSigner> signers = [
-    MultisigSigner(
-      id: 0,
-      innerVaultId: 1,
-      name: "Inside Wallet",
-      iconIndex: 0,
-      colorIndex: 0,
-      signerBsms: internalWalletBsms,
-      keyStore: keyStores[0],
-    ),
-    MultisigSigner(
-      id: 0,
-      signerBsms: outsideWalletBsms,
-      name: outsideWalletBsms.split('\n')[3],
-      memo: 'memo test',
-      keyStore: keyStores[1],
-    ),
-  ];
-
-  await walletProvider.addMultisigVault(
-    "Test Wallet2",
-    0,
-    0,
-    signers,
-    2,
-  );
-
-  return 2;
 }

--- a/lib/managers/wallet_list_manager.dart
+++ b/lib/managers/wallet_list_manager.dart
@@ -57,17 +57,15 @@ class WalletListManager {
     return jsonDecode(jsonArrayString);
   }
 
-  Future loadAndEmitEachWallet(List<dynamic> jsonList,
-      Function(VaultListItemBase wallet) emitOneItem) async {
+  Future loadAndEmitEachWallet(
+      List<dynamic> jsonList, Function(VaultListItemBase wallet) emitOneItem) async {
     _walletLoadCancelToken = Completer<void>();
 
     List<VaultListItemBase> vaultList = [];
 
     var initIsolateHandler =
-        IsolateHandler<Map<String, dynamic>, VaultListItemBase>(
-            initializeWallet);
-    await initIsolateHandler.initialize(
-        initialType: InitializeType.initializeWallet);
+        IsolateHandler<Map<String, dynamic>, VaultListItemBase>(initializeWallet);
+    await initIsolateHandler.initialize(initialType: InitializeType.initializeWallet);
 
     for (int i = 0; i < jsonList.length; i++) {
       if (jsonList[i][vaultTypeField] == WalletType.singleSignature.name) {
@@ -92,8 +90,7 @@ class WalletListManager {
     _vaultList = vaultList;
   }
 
-  Future<SingleSigVaultListItem> addSinglesigWallet(
-      SinglesigWallet wallet) async {
+  Future<SingleSigVaultListItem> addSinglesigWallet(SinglesigWallet wallet) async {
     if (_vaultList == null) {
       throw "[wallet_list_manager/addSinglesigWallet()] _vaultList is null. Load first.";
     }
@@ -103,22 +100,18 @@ class WalletListManager {
     final Map<String, dynamic> vaultData = wallet.toJson();
 
     var addVaultIsolateHandler =
-        IsolateHandler<Map<String, dynamic>, List<SingleSigVaultListItem>>(
-            addVaultIsolate);
-    await addVaultIsolateHandler.initialize(
-        initialType: InitializeType.addVault);
+        IsolateHandler<Map<String, dynamic>, List<SingleSigVaultListItem>>(addVaultIsolate);
+    await addVaultIsolateHandler.initialize(initialType: InitializeType.addVault);
     List<SingleSigVaultListItem> vaultListResult =
         await addVaultIsolateHandler.runAddVault(vaultData);
     addVaultIsolateHandler.dispose();
 
     _linkNewSinglesigVaultAndMultisigVaults(vaultListResult.first);
 
-    String keyString =
-        _createWalletKeyString(nextId, WalletType.singleSignature);
+    String keyString = _createWalletKeyString(nextId, WalletType.singleSignature);
     _storageService.write(
         key: keyString,
-        value: jsonEncode(
-            Secret(wallet.mnemonic!, wallet.passphrase ?? '').toJson()));
+        value: jsonEncode(Secret(wallet.mnemonic!, wallet.passphrase ?? '').toJson()));
 
     _vaultList!.add(vaultListResult[0]);
     try {
@@ -138,20 +131,17 @@ class WalletListManager {
   Future<void> _savePublicInfo() async {
     if (_vaultList == null) return;
 
-    final jsonString =
-        jsonEncode(_vaultList!.map((item) => item.toJson()).toList());
+    final jsonString = jsonEncode(_vaultList!.map((item) => item.toJson()).toList());
 
     //printLongString("--> 저장: $jsonString");
     await _sharedPrefs.setString(SharedPrefsKeys.kVaultListField, jsonString);
   }
 
   Future<void> _removePublicInfo() async {
-    await _sharedPrefs
-        .deleteSharedPrefsWithKey(SharedPrefsKeys.kVaultListField);
+    await _sharedPrefs.deleteSharedPrefsWithKey(SharedPrefsKeys.kVaultListField);
   }
 
-  void _linkNewSinglesigVaultAndMultisigVaults(
-      SingleSigVaultListItem singlesigItem) {
+  void _linkNewSinglesigVaultAndMultisigVaults(SingleSigVaultListItem singlesigItem) {
     outerLoop:
     for (int i = 0; i < _vaultList!.length; i++) {
       VaultListItemBase vault = _vaultList![i];
@@ -160,9 +150,8 @@ class WalletListManager {
 
       List<MultisigSigner> signers = (vault as MultisigVaultListItem).signers;
       // 멀티 시그만 판단
-      String importedMfp = (singlesigItem.coconutVault as SingleSignatureVault)
-          .keyStore
-          .masterFingerprint;
+      String importedMfp =
+          (singlesigItem.coconutVault as SingleSignatureVault).keyStore.masterFingerprint;
       for (int j = 0; j < signers.length; j++) {
         String signerMfp = signers[j].keyStore.masterFingerprint;
 
@@ -200,12 +189,9 @@ class WalletListManager {
     final Map<String, dynamic> data = wallet.toJson();
 
     var addMultisigVaultIsolateHandler =
-        IsolateHandler<Map<String, dynamic>, MultisigVaultListItem>(
-            addMultisigVaultIsolate);
-    await addMultisigVaultIsolateHandler.initialize(
-        initialType: InitializeType.addMultisigVault);
-    MultisigVaultListItem newMultisigVault =
-        await addMultisigVaultIsolateHandler.run(data);
+        IsolateHandler<Map<String, dynamic>, MultisigVaultListItem>(addMultisigVaultIsolate);
+    await addMultisigVaultIsolateHandler.initialize(initialType: InitializeType.addMultisigVault);
+    MultisigVaultListItem newMultisigVault = await addMultisigVaultIsolateHandler.run(data);
     addMultisigVaultIsolateHandler.dispose();
 
     // for SinglesigVaultListItem multsig key map update
@@ -227,8 +213,7 @@ class WalletListManager {
       var signer = signers[i];
       if (signers[i].innerVaultId == null) continue;
       SingleSigVaultListItem ssv = _vaultList!
-              .firstWhere((element) => element.id == signer.innerVaultId!)
-          as SingleSigVaultListItem;
+          .firstWhere((element) => element.id == signer.innerVaultId!) as SingleSigVaultListItem;
 
       var keyMap = {newWalletId: i};
       if (ssv.linkedMultisigInfo != null) {
@@ -249,8 +234,8 @@ class WalletListManager {
   }
 
   Future<Secret> getSecret(int id) async {
-    var secretString = await _storageService.read(
-        key: _createWalletKeyString(id, WalletType.singleSignature));
+    var secretString =
+        await _storageService.read(key: _createWalletKeyString(id, WalletType.singleSignature));
     return Secret.fromJson(jsonDecode(secretString!));
   }
 
@@ -266,8 +251,7 @@ class WalletListManager {
       final multi = getVaultById(id) as MultisigVaultListItem;
       for (var signer in multi.signers) {
         if (signer.innerVaultId != null) {
-          SingleSigVaultListItem ssv =
-              getVaultById(signer.innerVaultId!) as SingleSigVaultListItem;
+          SingleSigVaultListItem ssv = getVaultById(signer.innerVaultId!) as SingleSigVaultListItem;
           ssv.linkedMultisigInfo!.remove(id);
         }
       }
@@ -299,23 +283,20 @@ class WalletListManager {
     await _savePublicInfo();
   }
 
-  Future<bool> updateWallet(
-      int id, String newName, int colorIndex, int iconIndex) async {
+  Future<bool> updateWallet(int id, String newName, int colorIndex, int iconIndex) async {
     if (_vaultList == null) {
       throw Exception('[wallet_list_manager/updateWallet]: vaultList is empty');
     }
 
     final index = _vaultList!.indexWhere((item) => item.id == id);
     if (_vaultList![index].vaultType == WalletType.singleSignature) {
-      SingleSigVaultListItem singleSigVault =
-          _vaultList![index] as SingleSigVaultListItem;
+      SingleSigVaultListItem singleSigVault = _vaultList![index] as SingleSigVaultListItem;
       Map<int, int>? linkedMultisigInfo = singleSigVault.linkedMultisigInfo;
       // 연결된 MultisigVaultListItem의 signers 객체도 UI 업데이트가 필요
       if (linkedMultisigInfo != null && linkedMultisigInfo.isNotEmpty) {
         for (var entry in linkedMultisigInfo.entries) {
           if (getVaultById(id) != null) {
-            MultisigVaultListItem msv =
-                getVaultById(entry.key) as MultisigVaultListItem;
+            MultisigVaultListItem msv = getVaultById(entry.key) as MultisigVaultListItem;
             msv.signers[entry.value].name = newName;
             msv.signers[entry.value].colorIndex = colorIndex;
             msv.signers[entry.value].iconIndex = iconIndex;
@@ -343,8 +324,7 @@ class WalletListManager {
     return _vaultList?.firstWhere((element) => element.id == id);
   }
 
-  Future<MultisigVaultListItem> updateMemo(
-      int walletId, int signerIndex, String? newMemo) async {
+  Future<MultisigVaultListItem> updateMemo(int walletId, int signerIndex, String? newMemo) async {
     var wallet = getVaultById(walletId);
     assert(wallet != null);
     (wallet as MultisigVaultListItem).signers[signerIndex].memo = newMemo;
@@ -356,26 +336,21 @@ class WalletListManager {
   Future<void> resetAll() async {
     _vaultList?.clear();
 
-    await UpdatePreparation
-        .clearUpdatePreparationStorage(); // 비밀번호 초기화시 백업파일도 같이 삭제
+    await UpdatePreparation.clearUpdatePreparationStorage(); // 비밀번호 초기화시 백업파일도 같이 삭제
 
     await _storageService.deleteAll();
     await _removePublicInfo();
   }
 
-  Future<void> restoreFromBackupData(
-      List<Map<String, dynamic>> backupData) async {
+  Future<void> restoreFromBackupData(List<Map<String, dynamic>> backupData) async {
     final List<VaultListItemBase> vaultList = [];
     var initIsolateHandler =
-        IsolateHandler<Map<String, dynamic>, VaultListItemBase>(
-            initializeWallet);
-    await initIsolateHandler.initialize(
-        initialType: InitializeType.initializeWallet);
+        IsolateHandler<Map<String, dynamic>, VaultListItemBase>(initializeWallet);
+    await initIsolateHandler.initialize(initialType: InitializeType.initializeWallet);
     for (final data in backupData) {
       VaultListItemBase wallet = await initIsolateHandler.run(data);
       if (data['vaultType'] == WalletType.singleSignature.name) {
-        String keyString =
-            _createWalletKeyString(wallet.id, WalletType.singleSignature);
+        String keyString = _createWalletKeyString(wallet.id, WalletType.singleSignature);
         _storageService.write(
             key: keyString,
             value: jsonEncode(Secret(data[SingleSigVaultListItem.secretField],
@@ -394,8 +369,7 @@ class WalletListManager {
   ///
   /// 마이그레이션 진행 여부를 반환합니다.
   Future<bool> _migrateToVer2() async {
-    var previousData =
-        await _storageService.read(key: SharedPrefsKeys.kVaultListField);
+    var previousData = await _storageService.read(key: SharedPrefsKeys.kVaultListField);
     if (previousData == null || previousData.isEmpty) {
       return false;
     }
@@ -412,8 +386,7 @@ class WalletListManager {
 
       String keyString = _createWalletKeyString(id, WalletType.singleSignature);
       _storageService.write(
-          key: keyString,
-          value: jsonEncode(Secret(mnemonic, passphrase ?? '').toJson()));
+          key: keyString, value: jsonEncode(Secret(mnemonic, passphrase ?? '').toJson()));
 
       newJsonList.add({
         "id": id,
@@ -434,7 +407,9 @@ class WalletListManager {
 
   void dispose() {
     try {
-      _walletLoadCancelToken?.complete();
+      if (_walletLoadCancelToken != null && !_walletLoadCancelToken!.isCompleted) {
+        _walletLoadCancelToken!.complete();
+      }
     } catch (e) {
       Logger.error(e);
     }

--- a/lib/providers/view_model/start_view_model.dart
+++ b/lib/providers/view_model/start_view_model.dart
@@ -62,13 +62,13 @@ class StartViewModel extends ChangeNotifier {
         // 업데이트 하지 않음
         return AppEntryFlow.foundBackupFile;
       }
-    } else {
-      /// 비밀번호 등록 되어 있더라도, 추가한 볼트가 없는 경우는 볼트 리스트 화면으로 이동합니다.
-      if (_isWalletExistent()) {
-        return AppEntryFlow.pinCheck;
-      }
-      // 복원파일 없음 - 일반적인 최초 진입 흐름
-      return AppEntryFlow.vaultList;
     }
+
+    /// 비밀번호 등록 되어 있더라도, 추가한 볼트가 없는 경우는 볼트 리스트 화면으로 이동합니다.
+    if (_isWalletExistent()) {
+      return AppEntryFlow.pinCheck;
+    }
+    // 복원파일 없음 - 일반적인 최초 진입 흐름
+    return AppEntryFlow.vaultList;
   }
 }

--- a/lib/providers/view_model/start_view_model.dart
+++ b/lib/providers/view_model/start_view_model.dart
@@ -25,9 +25,7 @@ class StartViewModel extends ChangeNotifier {
   bool get hasSeenGuide => _hasSeenGuide;
 
   bool _isWalletExistent() {
-    return (SharedPrefsRepository().getInt(SharedPrefsKeys.vaultListLength) ??
-            0) >
-        0;
+    return (SharedPrefsRepository().getInt(SharedPrefsKeys.vaultListLength) ?? 0) > 0;
   }
 
   void updateConnectivityState() {
@@ -43,9 +41,7 @@ class StartViewModel extends ChangeNotifier {
     final isBluetoothOn = _connectivityProvider.isBluetoothOn;
     final isDeveloperModeOn = _connectivityProvider.isDeveloperModeOn;
 
-    if (isNetworkOn == null ||
-        isBluetoothOn == null ||
-        isDeveloperModeOn == null) return null;
+    if (isNetworkOn == null || isBluetoothOn == null || isDeveloperModeOn == null) return null;
 
     if (Platform.isAndroid) {
       return isNetworkOn || isBluetoothOn || isDeveloperModeOn;
@@ -55,13 +51,7 @@ class StartViewModel extends ChangeNotifier {
   }
 
   Future<AppEntryFlow> getNextEntryFlow() async {
-    /// 비밀번호 등록 되어 있더라도, 추가한 볼트가 없는 경우는 볼트 리스트 화면으로 이동합니다.
-    if (_isWalletExistent()) {
-      return AppEntryFlow.pinCheck;
-    }
-
-    final isRestorationPrepared =
-        await UpdatePreparation.isRestorationPrepared();
+    final isRestorationPrepared = await UpdatePreparation.isRestorationPrepared();
     // 복원파일 유무를 확인합니다.
     if (isRestorationPrepared) {
       // 복원파일 있음
@@ -73,6 +63,10 @@ class StartViewModel extends ChangeNotifier {
         return AppEntryFlow.foundBackupFile;
       }
     } else {
+      /// 비밀번호 등록 되어 있더라도, 추가한 볼트가 없는 경우는 볼트 리스트 화면으로 이동합니다.
+      if (_isWalletExistent()) {
+        return AppEntryFlow.pinCheck;
+      }
       // 복원파일 없음 - 일반적인 최초 진입 흐름
       return AppEntryFlow.vaultList;
     }


### PR DESCRIPTION
### 변경사항
 - AppFlow 검증 테스트 코드 추가(integration_test/app_flow_test.dart)
 - 테스트 유틸 함수 추가

### 테스트 방법
1. 명령어를 통한 통합테스트 코드 실행
flutter test integration_test/app_flow_test.dart --flavor regtest

### 테스트 시나리오
1. 앱 첫 시작 시 Tutorial 화면으로 진입하는지 확인하는 통합 테스트
2. 추가된 지갑이 있을 때 PinCheckScreen -> VaultListScreen으로 진입하는지 확인하는 통합 테스트
3. 추가된 지갑이 없을 때 PinCheckScreen을 거치지 않고 바로 VaultListScreen으로 진입하는지 확인하는 통합 테스트
4. 복원 파일이 존재하고 앱 업데이트가 완료됐을 때 PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트
5. 복원 파일이 존재하고 앱 업데이트가 안됐을 때 RestorationInfoScreen -> PinCheckScreen -> VaultListRestorationScreen으로 진입하는지 확인하는 통합 테스트

#124 