### PR TITLE
[126] 업데이트 준비 화면 진입 시 모든 볼트가 로드 완료되면 진행 가능하도록 변경

### DIFF
--- a/lib/providers/view_model/app_update_preparation_view_model.dart
+++ b/lib/providers/view_model/app_update_preparation_view_model.dart
@@ -45,10 +45,20 @@ class AppUpdatePreparationViewModel extends ChangeNotifier {
   Completer<void>? _progress80Reached;
 
   AppUpdatePreparationViewModel(this._walletProvider) {
+    _walletProvider.isVaultListLoadingNotifier.addListener(_loadVaultCompletedListener);
     _initialize();
   }
 
+  void _loadVaultCompletedListener() {
+    if (!_walletProvider.isVaultListLoading) {
+      _initialize();
+    }
+  }
+
   Future<void> _initialize() async {
+    // 모든 볼트가 로드될 때까지 대기
+    if (_walletProvider.isVaultListLoadingNotifier.value) return;
+
     List<VaultListItemBase> filteredList =
         _walletProvider.getVaultsByWalletType(WalletType.singleSignature);
     if (filteredList.isEmpty) {

--- a/lib/screens/app_update/app_update_preparation_screen.dart
+++ b/lib/screens/app_update/app_update_preparation_screen.dart
@@ -160,6 +160,16 @@ class _AppUpdatePreparationScreenState extends State<AppUpdatePreparationScreen>
                             bottom: 40,
                             child: _buildNextButton(viewModel),
                           ),
+                        if (!viewModel.isMnemonicLoaded)
+                          // 뒤로가기는 가능해야 하기 때문에 loaderOverlay를 사용하지 않고 별도 구현
+                          Container(
+                            width: MediaQuery.sizeOf(context).width,
+                            height: MediaQuery.sizeOf(context).height,
+                            color: Colors.white.withOpacity(0.5),
+                            child: const Center(
+                              child: CoconutCircularIndicator(),
+                            ),
+                          )
                       ],
                     ),
                   ),


### PR DESCRIPTION
### 변경사항
- (+) WalletProvider가 가지고 있던 isVaultListLoadingNotifier를 이용해 구현
- (+) viewModel 생성시 initialize할 때 isVaultListLoadingNotifier.value가 true(볼트 로드 중)이면 initialize를 대기하도록 수정
- (+) Screen에서 initialize가 미완료(viewModel.isMnemonicLoaded = false) 상태인 동안에는 CircularIndicator가 보이도록 처리

#126