### PR TITLE
핀 체크 화면에 진입 후 잠시 입력 불가 상태

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -54,11 +54,25 @@ class AuthProvider extends ChangeNotifier {
   int _currentAttemptInTurn = 0;
   int get currentAttemptInTurn => _currentAttemptInTurn;
   String _unlockAvailableAtInString = '';
-  DateTime? get unlockAvailableAt => _unlockAvailableAtInString.isEmpty
-      ? (_currentTurn == 0
-          ? DateTime.now()
-          : DateTime.now().add(Duration(minutes: kLockoutDurationsPerTurn[0])))
-      : (_unlockAvailableAtInString == '-1' ? null : DateTime.tryParse(_unlockAvailableAtInString));
+  DateTime? get unlockAvailableAt {
+    if (_unlockAvailableAtInString.isEmpty) {
+      if (_currentTurn == 0) {
+        Logger.log('--> current turn is 0, so return DateTime.now()');
+        return DateTime.now();
+      } else {
+        Logger.log(
+            '--> current turn is not 0, so return DateTime.now().add(Duration(minutes: ${kLockoutDurationsPerTurn[0]}))');
+        return DateTime.now().add(Duration(minutes: kLockoutDurationsPerTurn[0]));
+      }
+    } else if (_unlockAvailableAtInString == '-1') {
+      Logger.log('--> unlockAvailableAtInString is -1, so return null');
+      return null;
+    } else {
+      Logger.log(
+          '--> unlockAvailableAtInString is not empty, so return DateTime.tryParse($_unlockAvailableAtInString)');
+      return DateTime.tryParse(_unlockAvailableAtInString);
+    }
+  }
 
   int get remainingAttemptCount => kMaxAttemptPerTurn - _currentAttemptInTurn;
   bool get isPermanantlyLocked => _currentTurn == kMaxTurn;

--- a/lib/screens/common/pin_check_screen.dart
+++ b/lib/screens/common/pin_check_screen.dart
@@ -49,7 +49,7 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
 
   // when widget.appEntrance is true
   bool _isPaused = false;
-  bool _isUnlockDisabled = false;
+  bool? _isUnlockDisabled;
   bool _isLastChanceToTry = false;
 
   @override
@@ -121,7 +121,7 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
   }
 
   void _onKeyTap(String value) async {
-    if (_isUnlockDisabled || _isAppLaunched && _authProvider.isPermanantlyLocked) return;
+    if (_isUnlockDisabled == true || _isAppLaunched && _authProvider.isPermanantlyLocked) return;
 
     if (value == kBiometricIdentifier) {
       _authProvider.verifyBiometric(context);
@@ -163,8 +163,9 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
   void _verifyPin() async {
     context.loaderOverlay.show();
     bool isAuthenticated = await _authProvider.verifyPin(_pin);
-    context.loaderOverlay.hide();
-
+    if (mounted) {
+      context.loaderOverlay.hide();
+    }
     if (isAuthenticated) {
       _handleAuthenticationSuccess();
       return;
@@ -285,7 +286,9 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
         cancelButtonText: t.close, onConfirm: () async {
       await _authProvider.resetPin();
 
-      Navigator.of(context).pop();
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
       widget.onReset?.call();
     }, onCancel: () {
       Navigator.of(context).pop();
@@ -347,7 +350,7 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
       step: 0,
       lastChance: _isLastChanceToTry,
       lastChanceMessage: t.pin_check_screen.warning,
-      disabled: _authProvider.isPermanantlyLocked || _isUnlockDisabled,
+      disabled: _authProvider.isPermanantlyLocked || _isUnlockDisabled == true,
     );
   }
 

--- a/lib/screens/common/pin_check_screen.dart
+++ b/lib/screens/common/pin_check_screen.dart
@@ -82,7 +82,13 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
       if (!_authProvider.isUnlockAvailable()) {
         setState(() {
           _isUnlockDisabled = true;
+          Logger.log('--> set _isUnlockDisabled to true');
           _startCountdownTimerUntil(_authProvider.unlockAvailableAt ?? DateTime.now());
+        });
+      } else {
+        setState(() {
+          _isUnlockDisabled = false;
+          Logger.log('--> set _isUnlockDisabled to false');
         });
       }
     });
@@ -121,7 +127,9 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
   }
 
   void _onKeyTap(String value) async {
-    if (_isUnlockDisabled == true || _isAppLaunched && _authProvider.isPermanantlyLocked) return;
+    if (_isUnlockDisabled == null ||
+        _isUnlockDisabled == true ||
+        _isAppLaunched && _authProvider.isPermanantlyLocked) return;
 
     if (value == kBiometricIdentifier) {
       _authProvider.verifyBiometric(context);
@@ -193,6 +201,7 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
         setState(() {
           _errorMessage = '';
           _isUnlockDisabled = true;
+          Logger.log('--> set _isUnlockDisabled to true');
         });
 
         final nextUnlockTime = _authProvider.unlockAvailableAt;
@@ -226,7 +235,7 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
         setState(() {
           _errorMessage = '';
           _isUnlockDisabled = false;
-
+          Logger.log('--> set _isUnlockDisabled to false');
           if (_authProvider.currentTurn + 1 == kMaxTurn) {
             _isLastChanceToTry = true;
           }
@@ -331,6 +340,8 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
   }
 
   Widget _pinInputScreen({isOnReset = false}) {
+    Logger.log(
+        '--> PinInputScreen isPermanantlyLocked: ${_authProvider.isPermanantlyLocked} / isUnlockDisabled: ${_isUnlockDisabled}');
     return PinInputScreen(
       appBarVisible: _isAppLaunched ? false : true,
       title: _isAppLaunched ? '' : t.pin_check_screen.enter_password,


### PR DESCRIPTION
#131 에서 into branch를 develop으로 변경

설명
모든 플로우의 핀 체크 화면에 진입 후
초기 입력 전, 1초 미만 입력 불가 상태로 보이면서 앱이 잠시 멈춘 것 같은 느낌이 듭니다.
※ 생체 인증이 disabled 상태일 때 증상이 잘보입니다.

변경사항
pin check screen의 _isUnlockDisabled 초기 상태를 null로 변경하고, _isUnlockDisabled == true 인 경우, disable 처리