### PR TITLE
chore(debug-mode): debug 모드에서 스크린샷 허용

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,11 +1,13 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 project 'Runner', {
   'Debug' => :debug,
+  'Debug-regtest' => :debug,
+  'Debug-regtestlocal' => :debug,
   'Profile' => :release,
   'Release' => :release,
 }
@@ -29,7 +31,7 @@ flutter_ios_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  use_modular_headers!
+  #use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,15 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		1A2B8B8E5585F56209938121 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 86180149F3F9BA69A274028F /* Pods_RunnerTests.framework */; };
+		1BD069EBA6239E80D18E7C26 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F0B388DD831EB075CA41ACA /* Pods_RunnerTests.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		61332B7A2A269D4DBC0671ED /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4CC21D43229CD3F1A897607 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		791FA6C11C311C5131F5B188 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34524884BB741FB4A6CCDFBE /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		B289C44DCA445FF82323ADCF /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4CC21D43229CD3F1A897607 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,24 +42,29 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0BEFE4E29002265EE25F6EBD /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		02761CB4884191AAD82CFFC7 /* Pods-Runner.release-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-regtestlocal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-regtestlocal.xcconfig"; sourceTree = "<group>"; };
+		0FB25F23C3B3E4A84D968391 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		1F246FAABA18BD5224340498 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		2CEC7E447417F2B24D186697 /* Pods-RunnerTests.debug-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug-regtest.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug-regtest.xcconfig"; sourceTree = "<group>"; };
-		2E80CD044644FF2F91CE870E /* Pods-RunnerTests.release-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release-regtestlocal.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release-regtestlocal.xcconfig"; sourceTree = "<group>"; };
-		2FA467D3DAADD3F4B3AA1A7C /* Pods-Runner.debug-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-regtestlocal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-regtestlocal.xcconfig"; sourceTree = "<group>"; };
+		19EFE348A86DFDF3F0305FA2 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		1F0B388DD831EB075CA41ACA /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		21CD2E452A89999FD1BE35A4 /* Pods-Runner.debug-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-regtest.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-regtest.xcconfig"; sourceTree = "<group>"; };
+		25B807CF8882E745EE89F3F0 /* Pods-RunnerTests.debug-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug-regtest.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug-regtest.xcconfig"; sourceTree = "<group>"; };
+		314A8D0FA0062B84F8C4FDC7 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		34524884BB741FB4A6CCDFBE /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		3F9F0DAC6A3B786FFBAFFAA9 /* Pods-Runner.profile-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-regtestlocal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-regtestlocal.xcconfig"; sourceTree = "<group>"; };
-		4602856D37358AF5842B3AB2 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
-		4EC4558A73DF814234B4704C /* Pods-RunnerTests.debug-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug-regtestlocal.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug-regtestlocal.xcconfig"; sourceTree = "<group>"; };
-		66456374D324C56B328DE449 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		479F538FB9473F469BEDF745 /* Pods-Runner.profile-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-regtestlocal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-regtestlocal.xcconfig"; sourceTree = "<group>"; };
+		4EA6FA1F57CEB85D7DC90516 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		4FF49A7758D3E65B884B71AA /* Pods-Runner.release-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-regtest.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-regtest.xcconfig"; sourceTree = "<group>"; };
+		61F6F6D26281475EE0C0EA2C /* Pods-RunnerTests.release-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release-regtest.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release-regtest.xcconfig"; sourceTree = "<group>"; };
+		70B840FC8FF9AA9D15FD0F57 /* Pods-RunnerTests.debug-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug-regtestlocal.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug-regtestlocal.xcconfig"; sourceTree = "<group>"; };
+		742714AFAEA9B5093E421749 /* Pods-RunnerTests.profile-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile-regtest.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile-regtest.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		86180149F3F9BA69A274028F /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7C8C75E3DB1995CE457E6DF2 /* Pods-Runner.profile-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-regtest.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-regtest.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -68,17 +72,12 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A37B19003F977F059236C588 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		A76D931F201D4451227E2B90 /* Pods-Runner.release-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-regtest.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-regtest.xcconfig"; sourceTree = "<group>"; };
-		A95A1B230C2703419355C30F /* Pods-Runner.debug-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-regtest.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-regtest.xcconfig"; sourceTree = "<group>"; };
-		B025BAD4A2016CEE93845013 /* Pods-RunnerTests.release-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release-regtest.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release-regtest.xcconfig"; sourceTree = "<group>"; };
-		B4CC21D43229CD3F1A897607 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BC78EBF9ABEBE1EFB32A8198 /* Pods-RunnerTests.profile-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile-regtest.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile-regtest.xcconfig"; sourceTree = "<group>"; };
+		9F574C5B5704171F2E2F7545 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		9FE8A6D5350B9A8D03256970 /* Pods-RunnerTests.release-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release-regtestlocal.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release-regtestlocal.xcconfig"; sourceTree = "<group>"; };
 		C2C4B44E2C76E072009809A2 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
-		D11993D724A15C2C7A9A5928 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		D58AF497FD7E3F6B562F777B /* Pods-Runner.release-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-regtestlocal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-regtestlocal.xcconfig"; sourceTree = "<group>"; };
-		DD9064149DDFF7B1A6A2BD97 /* Pods-Runner.profile-regtest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile-regtest.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile-regtest.xcconfig"; sourceTree = "<group>"; };
-		E969B122BA1DFA09E02ACC83 /* Pods-RunnerTests.profile-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile-regtestlocal.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile-regtestlocal.xcconfig"; sourceTree = "<group>"; };
+		C552C406EF0DA05473C16C24 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D4304EBB91225AD4CA7BF94D /* Pods-Runner.debug-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug-regtestlocal.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug-regtestlocal.xcconfig"; sourceTree = "<group>"; };
+		EC1999A8D0E2FFE08E3590F9 /* Pods-RunnerTests.profile-regtestlocal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile-regtestlocal.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile-regtestlocal.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -86,7 +85,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A2B8B8E5585F56209938121 /* Pods_RunnerTests.framework in Frameworks */,
+				1BD069EBA6239E80D18E7C26 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,23 +93,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B289C44DCA445FF82323ADCF /* Pods_Runner.framework in Frameworks */,
-				61332B7A2A269D4DBC0671ED /* Pods_Runner.framework in Frameworks */,
+				791FA6C11C311C5131F5B188 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0F7704AB0E4C8B9907208526 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				B4CC21D43229CD3F1A897607 /* Pods_Runner.framework */,
-				86180149F3F9BA69A274028F /* Pods_RunnerTests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -138,7 +127,7 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				E48BBBE0D78E0F177430406F /* Pods */,
-				0F7704AB0E4C8B9907208526 /* Frameworks */,
+				D313A9067D8DE5DA1B94B2EF /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -167,27 +156,36 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		D313A9067D8DE5DA1B94B2EF /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				34524884BB741FB4A6CCDFBE /* Pods_Runner.framework */,
+				1F0B388DD831EB075CA41ACA /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		E48BBBE0D78E0F177430406F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				D11993D724A15C2C7A9A5928 /* Pods-Runner.debug.xcconfig */,
-				1F246FAABA18BD5224340498 /* Pods-Runner.release.xcconfig */,
-				66456374D324C56B328DE449 /* Pods-Runner.profile.xcconfig */,
-				A37B19003F977F059236C588 /* Pods-RunnerTests.debug.xcconfig */,
-				0BEFE4E29002265EE25F6EBD /* Pods-RunnerTests.release.xcconfig */,
-				4602856D37358AF5842B3AB2 /* Pods-RunnerTests.profile.xcconfig */,
-				A95A1B230C2703419355C30F /* Pods-Runner.debug-regtest.xcconfig */,
-				A76D931F201D4451227E2B90 /* Pods-Runner.release-regtest.xcconfig */,
-				DD9064149DDFF7B1A6A2BD97 /* Pods-Runner.profile-regtest.xcconfig */,
-				2CEC7E447417F2B24D186697 /* Pods-RunnerTests.debug-regtest.xcconfig */,
-				B025BAD4A2016CEE93845013 /* Pods-RunnerTests.release-regtest.xcconfig */,
-				BC78EBF9ABEBE1EFB32A8198 /* Pods-RunnerTests.profile-regtest.xcconfig */,
-				2FA467D3DAADD3F4B3AA1A7C /* Pods-Runner.debug-regtestlocal.xcconfig */,
-				D58AF497FD7E3F6B562F777B /* Pods-Runner.release-regtestlocal.xcconfig */,
-				3F9F0DAC6A3B786FFBAFFAA9 /* Pods-Runner.profile-regtestlocal.xcconfig */,
-				4EC4558A73DF814234B4704C /* Pods-RunnerTests.debug-regtestlocal.xcconfig */,
-				2E80CD044644FF2F91CE870E /* Pods-RunnerTests.release-regtestlocal.xcconfig */,
-				E969B122BA1DFA09E02ACC83 /* Pods-RunnerTests.profile-regtestlocal.xcconfig */,
+				314A8D0FA0062B84F8C4FDC7 /* Pods-Runner.debug.xcconfig */,
+				D4304EBB91225AD4CA7BF94D /* Pods-Runner.debug-regtestlocal.xcconfig */,
+				21CD2E452A89999FD1BE35A4 /* Pods-Runner.debug-regtest.xcconfig */,
+				4EA6FA1F57CEB85D7DC90516 /* Pods-Runner.release.xcconfig */,
+				02761CB4884191AAD82CFFC7 /* Pods-Runner.release-regtestlocal.xcconfig */,
+				4FF49A7758D3E65B884B71AA /* Pods-Runner.release-regtest.xcconfig */,
+				0FB25F23C3B3E4A84D968391 /* Pods-Runner.profile.xcconfig */,
+				479F538FB9473F469BEDF745 /* Pods-Runner.profile-regtestlocal.xcconfig */,
+				7C8C75E3DB1995CE457E6DF2 /* Pods-Runner.profile-regtest.xcconfig */,
+				C552C406EF0DA05473C16C24 /* Pods-RunnerTests.debug.xcconfig */,
+				70B840FC8FF9AA9D15FD0F57 /* Pods-RunnerTests.debug-regtestlocal.xcconfig */,
+				25B807CF8882E745EE89F3F0 /* Pods-RunnerTests.debug-regtest.xcconfig */,
+				19EFE348A86DFDF3F0305FA2 /* Pods-RunnerTests.release.xcconfig */,
+				9FE8A6D5350B9A8D03256970 /* Pods-RunnerTests.release-regtestlocal.xcconfig */,
+				61F6F6D26281475EE0C0EA2C /* Pods-RunnerTests.release-regtest.xcconfig */,
+				9F574C5B5704171F2E2F7545 /* Pods-RunnerTests.profile.xcconfig */,
+				EC1999A8D0E2FFE08E3590F9 /* Pods-RunnerTests.profile-regtestlocal.xcconfig */,
+				742714AFAEA9B5093E421749 /* Pods-RunnerTests.profile-regtest.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -199,7 +197,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				C9ACFCAB8E07E377593626D1 /* [CP] Check Pods Manifest.lock */,
+				9D860CF210E05A5F5336C7D6 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				1E1ADFBA8B459FE5C5736235 /* Frameworks */,
@@ -218,14 +216,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				2F98E7F18C6EB85873D60342 /* [CP] Check Pods Manifest.lock */,
+				2AC929F66FA6CA34D1841211 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				39E266CC6DF766B10FE2B425 /* [CP] Embed Pods Frameworks */,
+				3A357562303AD3455E4DACD1 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -297,7 +295,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2F98E7F18C6EB85873D60342 /* [CP] Check Pods Manifest.lock */ = {
+		2AC929F66FA6CA34D1841211 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -319,7 +317,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		39E266CC6DF766B10FE2B425 /* [CP] Embed Pods Frameworks */ = {
+		3A357562303AD3455E4DACD1 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -367,7 +365,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
 		};
-		C9ACFCAB8E07E377593626D1 /* [CP] Check Pods Manifest.lock */ = {
+		9D860CF210E05A5F5336C7D6 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -534,7 +532,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A37B19003F977F059236C588 /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = C552C406EF0DA05473C16C24 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -555,7 +553,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0BEFE4E29002265EE25F6EBD /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 19EFE348A86DFDF3F0305FA2 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -574,7 +572,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4602856D37358AF5842B3AB2 /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 9F574C5B5704171F2E2F7545 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -733,6 +731,7 @@
 				);
 				MARKETING_VERSION = 2.2.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = onl.coconut.vault;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -869,6 +868,7 @@
 				);
 				MARKETING_VERSION = 2.2.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = onl.coconut.vault.regtest.local;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -886,7 +886,7 @@
 		};
 		C28C2FF52C5A2E4E009D1E45 /* Debug-regtestlocal */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4EC4558A73DF814234B4704C /* Pods-RunnerTests.debug-regtestlocal.xcconfig */;
+			baseConfigurationReference = 70B840FC8FF9AA9D15FD0F57 /* Pods-RunnerTests.debug-regtestlocal.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1002,7 +1002,7 @@
 		};
 		C28C2FF82C5A2E5B009D1E45 /* Release-regtestlocal */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2E80CD044644FF2F91CE870E /* Pods-RunnerTests.release-regtestlocal.xcconfig */;
+			baseConfigurationReference = 9FE8A6D5350B9A8D03256970 /* Pods-RunnerTests.release-regtestlocal.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1114,7 +1114,7 @@
 		};
 		C28C2FFB2C5A2E64009D1E45 /* Profile-regtestlocal */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E969B122BA1DFA09E02ACC83 /* Pods-RunnerTests.profile-regtestlocal.xcconfig */;
+			baseConfigurationReference = EC1999A8D0E2FFE08E3590F9 /* Pods-RunnerTests.profile-regtestlocal.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1217,6 +1217,7 @@
 				);
 				MARKETING_VERSION = 2.2.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 gnu++11";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = onl.coconut.vault.regtest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1234,7 +1235,7 @@
 		};
 		DEC632D12C58EA4300973B4A /* Debug-regtest */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2CEC7E447417F2B24D186697 /* Pods-RunnerTests.debug-regtest.xcconfig */;
+			baseConfigurationReference = 25B807CF8882E745EE89F3F0 /* Pods-RunnerTests.debug-regtest.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1351,7 +1352,7 @@
 		};
 		DEC632D42C58EA4D00973B4A /* Release-regtest */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B025BAD4A2016CEE93845013 /* Pods-RunnerTests.release-regtest.xcconfig */;
+			baseConfigurationReference = 61F6F6D26281475EE0C0EA2C /* Pods-RunnerTests.release-regtest.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1464,7 +1465,7 @@
 		};
 		DEC632D72C58EA5400973B4A /* Profile-regtest */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BC78EBF9ABEBE1EFB32A8198 /* Pods-RunnerTests.profile-regtest.xcconfig */;
+			baseConfigurationReference = 742714AFAEA9B5093E421749 /* Pods-RunnerTests.profile-regtest.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -7,7 +7,11 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    self.window.makeSecure()
+    #if DEBUG
+    print("🔧 DEBUG 모드입니다. makeSecure()는 호출되지 않습니다.")
+    #else
+    self.window?.makeSecure()   
+    #endif
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,9 +57,11 @@ void main() async {
 
   NetworkType.setNetworkType(NetworkType.regtest);
 
-  await ScreenProtector.protectDataLeakageWithImage('ScreenProtectImage'); // iOS
-  await ScreenProtector.protectDataLeakageOn(); // Android
-  await ScreenProtector.preventScreenshotOn(); // iOS and Android
+  if (!kDebugMode) {
+    await ScreenProtector.protectDataLeakageWithImage('ScreenProtectImage'); // iOS
+    await ScreenProtector.protectDataLeakageOn(); // Android
+    await ScreenProtector.preventScreenshotOn(); // iOS and Android
+  }
 
   return runApp(const CoconutVaultApp());
 }


### PR DESCRIPTION
#### 변경 사항
- Podfile 변경
- XCode debug 스킴에 대한 Build Setting 변경
- 디버그 모드에서만 스크린샷을 허용하도록 수정

<img width="679" alt="스크린샷 2025-04-21 오전 11 25 40" src="https://github.com/user-attachments/assets/7034d924-1458-4903-905e-fdd315e13f67" />

 TARGETS > Runner 
   - Build Settingd에서 'swift flag' 검색
   - Debug flag에 대해 `-D DEBUG`가 설정되어 있는지 확인합니다.

⚠️ Podfile이 바뀌었으므로, 다음 명령어 실행 후 빌드해 주세요

```
cd ios
rm -rf Pods Podfile.lock .symlinks Flutter/ephemeral
flutter pub get
pod install
```

이후 Xcode에서 
- Product > Clean Build Folder (⇧⌘K)
- Run (⌘R)