### PR TITLE
[139] 업데이트 준비 과정 니모닉 퀴즈 대문자 입력 허용

### DIFF
--- a/integration_test/update_preparation_test.dart
+++ b/integration_test/update_preparation_test.dart
@@ -38,69 +38,78 @@ void main() {
     await UpdatePreparation.clearUpdatePreparationStorage();
   });
 
+  Future<void> mnemonicCheckFlow(WidgetTester tester, bool uppercase) async {
+    await skipScreensUntilVaultList(tester);
+
+    // Save pin password 0000
+    final authProvider = Provider.of<AuthProvider>(
+      tester.element(find.byType(CupertinoApp)),
+      listen: false,
+    );
+    await authProvider.savePin("0000");
+
+    // Add Wallets on VaultListScreen
+    final walletProvider = Provider.of<WalletProvider>(
+      tester.element(find.byType(CupertinoApp)),
+      listen: false,
+    );
+    int count = await addWallets(walletProvider: walletProvider);
+    expect(walletProvider.vaultList.length, count);
+
+    count += await addSingleSigWallets(walletProvider: walletProvider);
+    expect(walletProvider.vaultList.length, count);
+
+    // VaultListScreen to UpdatePreparationScreen
+    await showUpdatePreparationScreen(tester);
+
+    final updatePreparationProvider = Provider.of<AppUpdatePreparationViewModel>(
+      tester.element(find.text(t.settings_screen.prepare_update)),
+      listen: false,
+    );
+
+    List<VaultListItemBase> singleSignVaults =
+        walletProvider.getVaultsByWalletType(WalletType.singleSignature);
+    // Check if mnemonic is loaded
+    expect(updatePreparationProvider.isMnemonicLoaded, true);
+
+    // Find TextInput for mnemonic validation
+    final Finder textInput = find.byType(CoconutTextField);
+    await waitForWidgetAndTap(tester, textInput, "textInput");
+
+    for (int i = 0; i < singleSignVaults.length; i++) {
+      // Load vault's mnemonicList
+      List<String> vaultMnemonicList = await walletProvider
+          .getSecret(singleSignVaults[i].id)
+          .then((secret) => secret.mnemonic.split(' '));
+
+      String title = t.prepare_update.enter_nth_word_of_wallet(
+        wallet_name: updatePreparationProvider.walletName,
+        n: updatePreparationProvider.mnemonicWordIndex,
+      );
+
+      // Check title Text
+      final Finder titleText = find.text(title);
+      expect(titleText, findsOneWidget);
+
+      // Input mnemonic to TextInput
+      String mnemonic = vaultMnemonicList[updatePreparationProvider.mnemonicWordIndex - 1];
+      await tester.enterText(textInput, uppercase ? mnemonic.toUpperCase() : mnemonic);
+      await tester.pumpAndSettle();
+    }
+
+    // Check if Logic is finished
+    expect(updatePreparationProvider.isMnemonicValidationFinished, true);
+  }
+
   group('UpdatePreparation Integration Tests', () {
     // 업데이트 준비 프로세스에서 싱글시그니처 월렛의 니모닉을 검증합니다.
     testWidgets('Mnemonic check test', (tester) async {
-      await skipScreensUntilVaultList(tester);
+      await mnemonicCheckFlow(tester, false);
+    });
 
-      // Save pin password 0000
-      final authProvider = Provider.of<AuthProvider>(
-        tester.element(find.byType(CupertinoApp)),
-        listen: false,
-      );
-      await authProvider.savePin("0000");
-
-      // Add Wallets on VaultListScreen
-      final walletProvider = Provider.of<WalletProvider>(
-        tester.element(find.byType(CupertinoApp)),
-        listen: false,
-      );
-      int count = await addWallets(walletProvider: walletProvider);
-      expect(walletProvider.vaultList.length, count);
-
-      count += await addSingleSigWallets(walletProvider: walletProvider);
-      expect(walletProvider.vaultList.length, count);
-
-      // VaultListScreen to UpdatePreparationScreen
-      await showUpdatePreparationScreen(tester);
-
-      final updatePreparationProvider = Provider.of<AppUpdatePreparationViewModel>(
-        tester.element(find.text(t.settings_screen.prepare_update)),
-        listen: false,
-      );
-
-      List<VaultListItemBase> singleSignVaults =
-          walletProvider.getVaultsByWalletType(WalletType.singleSignature);
-      // Check if mnemonic is loaded
-      expect(updatePreparationProvider.isMnemonicLoaded, true);
-
-      // Find TextInput for mnemonic validation
-      final Finder textInput = find.byType(CoconutTextField);
-      await waitForWidgetAndTap(tester, textInput, "textInput");
-
-      for (int i = 0; i < singleSignVaults.length; i++) {
-        // Load vault's mnemonicList
-        List<String> vaultMnemonicList = await walletProvider
-            .getSecret(singleSignVaults[i].id)
-            .then((secret) => secret.mnemonic.split(' '));
-
-        String title = t.prepare_update.enter_nth_word_of_wallet(
-          wallet_name: updatePreparationProvider.walletName,
-          n: updatePreparationProvider.mnemonicWordIndex,
-        );
-
-        // Check title Text
-        final Finder titleText = find.text(title);
-        expect(titleText, findsOneWidget);
-
-        // Input mnemonic to TextInput
-        await tester.enterText(
-            textInput, vaultMnemonicList[updatePreparationProvider.mnemonicWordIndex - 1]);
-        await tester.pumpAndSettle();
-      }
-
-      // Check if Logic is finished
-      expect(updatePreparationProvider.isMnemonicValidationFinished, true);
+    // 니모닉 확인시 대문자 입력이 가능해야 합니다.
+    testWidgets('Mnemonic check uppercase test', (tester) async {
+      await mnemonicCheckFlow(tester, true);
     });
 
     testWidgets('Backup and restore test', (tester) async {

--- a/lib/providers/view_model/app_update_preparation_view_model.dart
+++ b/lib/providers/view_model/app_update_preparation_view_model.dart
@@ -97,8 +97,8 @@ class AppUpdatePreparationViewModel extends ChangeNotifier {
   }
 
   bool isWordMatched(String userInput) {
-    final success =
-        hashString(userInput) == _mnemonicWordsItems[_currentMnemonicIndex].mnemonicWords;
+    final success = hashString(userInput.toLowerCase()) ==
+        _mnemonicWordsItems[_currentMnemonicIndex].mnemonicWords;
     if (!success) {
       return false;
     }

--- a/lib/screens/app_update/app_update_preparation_screen.dart
+++ b/lib/screens/app_update/app_update_preparation_screen.dart
@@ -371,7 +371,7 @@ class _AppUpdatePreparationScreenState extends State<AppUpdatePreparationScreen>
                 CoconutLayout.spacing_1500h,
                 CoconutTextField(
                   textInputFormatter: [
-                    FilteringTextInputFormatter.allow(RegExp(r'[a-z]')),
+                    FilteringTextInputFormatter.allow(RegExp(r'[a-zA-Z]')),
                   ],
                   controller: _mnemonicWordInputController,
                   focusNode: _mnemonicInputFocusNode,


### PR DESCRIPTION
### 변경사항
refactor(app_update_preparation_screen): 니모닉 대문자 입력 허용
feat(update_preparation_test): 니모닉 대문자 입력에 대한 테스트 추가

### 테스트 방법
1. 명령어를 통한 통합테스트 코드 실행
flutter test —plain-name "Mnemonic check uppercase test" --flavor regtest integration_test/update_preparation_test.dart

### 테스트 시나리오
1. 지갑 생성 후 업데이트 준비 화면 이동
2. 니모닉 정보를 대문자로 입력
3. 정상적으로 니모닉 확인이 끝나는지 확인 

#139 