### PR TITLE
[165] 앱 진입 시 생체인증, 비밀번호 확인

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -48,7 +48,7 @@ class AuthProvider extends ChangeNotifier {
   bool get hasBiometricsPermission => _hasBiometricsPermission;
 
   /// 인증 활성화 여부
-  bool get isAuthEnabled => isBiometricsAuthEnabled || _isPinSet;
+  bool get isAuthEnabled => _isPinSet;
 
   /// 생체인식 인증 활성화 여부
   bool get isBiometricsAuthEnabled => _canCheckBiometrics && _isBiometricEnabled;

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -43,11 +43,15 @@ class AuthProvider extends ChangeNotifier {
   bool _isBiometricEnabled = false;
   bool get isBiometricEnabled => _isBiometricEnabled;
 
-  bool get isBiometricAuthRequired => _isBiometricEnabled && _canCheckBiometrics;
-
   /// 사용자 생체인증 권한 허용 여부
   bool _hasBiometricsPermission = false;
   bool get hasBiometricsPermission => _hasBiometricsPermission;
+
+  /// 인증 활성화 여부
+  bool get isAuthEnabled => isBiometricsAuthEnabled || _isPinSet;
+
+  /// 생체인식 인증 활성화 여부
+  bool get isBiometricsAuthEnabled => _canCheckBiometrics && _isBiometricEnabled;
 
   /// 잠금 해제 시도 정보
   int _currentTurn = 0;
@@ -87,6 +91,11 @@ class AuthProvider extends ChangeNotifier {
     setInitState();
   }
 
+  /// 생체인증 성공했는지 여부 반환
+  Future<bool> isBiometricsAuthValid() async {
+    return isBiometricsAuthEnabled && await authenticateWithBiometrics();
+  }
+
   void setInitState() {
     _isPinSet = _sharedPrefs.getBool(SharedPrefsKeys.isPinEnabled) == true;
     _loadBiometricState();
@@ -113,8 +122,10 @@ class AuthProvider extends ChangeNotifier {
   }
 
   /// 생체인증 진행 후 성공 여부 반환
-  Future<bool> authenticateWithBiometrics(BuildContext context,
-      {bool showAuthenticationFailedDialog = true, bool isSaved = false}) async {
+  Future<bool> authenticateWithBiometrics(
+      {BuildContext? context,
+      bool showAuthenticationFailedDialog = true,
+      bool isSaved = false}) async {
     bool authenticated = false;
     try {
       authenticated = await _auth.authenticate(
@@ -129,7 +140,7 @@ class AuthProvider extends ChangeNotifier {
       );
 
       if (Platform.isIOS && !authenticated) {
-        if (context.mounted && onRequestShowAuthenticationFailedDialog != null) {
+        if (context != null && context.mounted && onRequestShowAuthenticationFailedDialog != null) {
           onRequestShowAuthenticationFailedDialog!();
         }
       }
@@ -149,7 +160,9 @@ class AuthProvider extends ChangeNotifier {
             !authenticated &&
             e.message == 'Biometry is not available.' &&
             showAuthenticationFailedDialog) {
-          if (context.mounted && onRequestShowAuthenticationFailedDialog != null) {
+          if (context != null &&
+              context.mounted &&
+              onRequestShowAuthenticationFailedDialog != null) {
             onRequestShowAuthenticationFailedDialog!();
           }
         }
@@ -177,7 +190,6 @@ class AuthProvider extends ChangeNotifier {
       }
 
       final List<BiometricType> availableBiometrics = await _auth.getAvailableBiometrics();
-
       _canCheckBiometrics = availableBiometrics.isNotEmpty;
 
       if (!_canCheckBiometrics) {
@@ -206,7 +218,7 @@ class AuthProvider extends ChangeNotifier {
 
   void verifyBiometric(BuildContext context) async {
     bool isAuthenticated = await authenticateWithBiometrics(
-      context,
+      context: context,
       showAuthenticationFailedDialog: false,
     );
     if (isAuthenticated) {

--- a/lib/screens/common/pin_check_screen.dart
+++ b/lib/screens/common/pin_check_screen.dart
@@ -72,7 +72,6 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
     WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await _authProvider.updateBiometricAvailability();
-      _checkBiometricsIfNeeds();
       if (mounted) {
         setState(() {
           _shuffledPinNumbers = _authProvider.getShuffledNumberList();
@@ -122,7 +121,6 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
     } else if (AppLifecycleState.resumed == state && _isPaused) {
       _isPaused = false;
       await _authProvider.updateBiometricAvailability();
-      _checkBiometricsIfNeeds();
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
           setState(() {
@@ -130,13 +128,6 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
           });
         }
       });
-    }
-  }
-
-  /// vault_list_tab screen, this screen pause -> Bio 체크
-  void _checkBiometricsIfNeeds() {
-    if (_authProvider.isBiometricAuthRequired) {
-      _authProvider.verifyBiometric(context);
     }
   }
 

--- a/lib/screens/common/start_screen.dart
+++ b/lib/screens/common/start_screen.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_vault/app.dart';
+import 'package:coconut_vault/providers/auth_provider.dart';
 import 'package:coconut_vault/providers/connectivity_provider.dart';
 import 'package:coconut_vault/providers/view_model/start_view_model.dart';
 import 'package:coconut_vault/providers/visibility_provider.dart';
@@ -25,7 +26,9 @@ class _StartScreenState extends State<StartScreen> {
   @override
   void initState() {
     super.initState();
-    _viewModel = StartViewModel(Provider.of<ConnectivityProvider>(context, listen: false),
+    _viewModel = StartViewModel(
+        Provider.of<ConnectivityProvider>(context, listen: false),
+        Provider.of<AuthProvider>(context, listen: false),
         Provider.of<VisibilityProvider>(context, listen: false).hasSeenGuide);
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {

--- a/lib/screens/settings/pin_setting_screen.dart
+++ b/lib/screens/settings/pin_setting_screen.dart
@@ -131,7 +131,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
             _authProvider.canCheckBiometrics &&
             !_authProvider.hasAlreadyRequestedBioPermission &&
             mounted) {
-          await _authProvider.authenticateWithBiometrics(context, isSaved: true);
+          await _authProvider.authenticateWithBiometrics(context: context, isSaved: true);
         }
 
         _finishPinSetting();

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/providers/auth_provider.dart';
 import 'package:coconut_vault/providers/visibility_provider.dart';
 import 'package:coconut_vault/providers/wallet_provider.dart';
+import 'package:coconut_vault/screens/settings/pin_setting_screen.dart';
 import 'package:coconut_vault/utils/logger.dart';
 import 'package:coconut_vault/widgets/custom_loading_overlay.dart';
 import 'package:flutter/cupertino.dart';
@@ -57,6 +58,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
+  void _showPinSettingScreen() {
+    MyBottomSheet.showBottomSheet_90(context: context, child: const PinSettingScreen());
+  }
+
   Widget _securityPart(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -78,7 +83,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       activeColor: CoconutColors.black,
                       onChanged: (isOn) async {
                         if (isOn &&
-                            await provider.authenticateWithBiometrics(context, isSaved: true)) {
+                            await provider.authenticateWithBiometrics(
+                                context: context, isSaved: true)) {
                           Logger.log('Biometric authentication success');
                           provider.saveIsBiometricEnabled(true);
                         } else {
@@ -94,6 +100,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       : SingleButtonPosition.none,
                   title: t.settings_screen.change_password,
                   onPressed: () async {
+                    final authProvider = context.read<AuthProvider>();
+                    if (await authProvider.isBiometricsAuthValid()) {
+                      _showPinSettingScreen();
+                      return;
+                    }
+
                     MyBottomSheet.showBottomSheet_90(
                       context: context,
                       child: const LoaderOverlay(
@@ -112,13 +124,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     value: provider.hasBiometricsPermission ? provider.isBiometricEnabled : false,
                     activeColor: CoconutColors.black,
                     onChanged: (isOn) async {
-                      if (isOn &&
-                          await provider.authenticateWithBiometrics(context, isSaved: true)) {
-                        Logger.log('Biometric authentication success');
-                        provider.saveIsBiometricEnabled(true);
-                      } else {
-                        Logger.log('Biometric authentication fail');
-                        provider.saveIsBiometricEnabled(false);
+                      /// 비밀번호 제거 기능은 제공하지 않음.
+                      if (isOn) {
+                        _showPinSettingScreen();
                       }
                     },
                   ),
@@ -148,6 +156,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
               buttonPosition: SingleButtonPosition.none,
               title: t.settings_screen.prepare_update,
               onPressed: () async {
+                final authProvider = context.read<AuthProvider>();
+                if (await authProvider.isBiometricsAuthValid()) {
+                  Navigator.pushNamed(context, AppRoutes.prepareUpdate);
+                  return;
+                }
+
                 MyBottomSheet.showBottomSheet_90(
                   context: context,
                   child: CustomLoadingOverlay(

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -37,9 +37,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
         title: t.settings,
         isBottom: true,
       ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: SingleChildScrollView(
           child: Column(
             children: [
               _securityPart(context),
@@ -51,6 +51,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     : Container(),
               ),
               _advancedUserPart(context),
+              SizedBox(
+                  height: MediaQuery.of(context).viewPadding.bottom > 0
+                      ? MediaQuery.of(context).viewPadding.bottom
+                      : Sizes.size16)
             ],
           ),
         ),

--- a/lib/screens/vault_menu/info/multisig_setup_info_screen.dart
+++ b/lib/screens/vault_menu/info/multisig_setup_info_screen.dart
@@ -5,6 +5,7 @@ import 'package:coconut_vault/constants/app_routes.dart';
 import 'package:coconut_vault/enums/pin_check_context_enum.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/model/multisig/multisig_signer.dart';
+import 'package:coconut_vault/providers/auth_provider.dart';
 import 'package:coconut_vault/providers/view_model/vault_menu/multisig_setup_info_view_model.dart';
 import 'package:coconut_vault/providers/wallet_provider.dart';
 import 'package:coconut_vault/screens/common/pin_check_screen.dart';
@@ -56,7 +57,18 @@ class _MultisigSetupInfoScreenState extends State<MultisigSetupInfoScreen> {
   Future _verifyBiometric(
     BuildContext context,
   ) async {
-    final viewModel = context.read<MultisigSetupInfoViewModel>();
+    void onComplete() {
+      context.read<MultisigSetupInfoViewModel>().deleteVault();
+      vibrateLight();
+      Navigator.popUntil(context, (route) => route.isFirst);
+    }
+
+    final authProvider = context.read<AuthProvider>();
+    if (await authProvider.isBiometricsAuthValid()) {
+      onComplete();
+      return;
+    }
+
     MyBottomSheet.showBottomSheet_90(
       context: context,
       child: CustomLoadingOverlay(
@@ -64,9 +76,7 @@ class _MultisigSetupInfoScreenState extends State<MultisigSetupInfoScreen> {
           pinCheckContext: PinCheckContextEnum.sensitiveAction,
           onComplete: () async {
             Navigator.pop(context);
-            viewModel.deleteVault();
-            vibrateLight();
-            Navigator.popUntil(context, (route) => route.isFirst);
+            onComplete();
           },
         ),
       ),

--- a/lib/screens/vault_menu/info/single_sig_setup_info_screen.dart
+++ b/lib/screens/vault_menu/info/single_sig_setup_info_screen.dart
@@ -4,6 +4,7 @@ import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_vault/constants/app_routes.dart';
 import 'package:coconut_vault/enums/pin_check_context_enum.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
+import 'package:coconut_vault/providers/auth_provider.dart';
 import 'package:coconut_vault/providers/view_model/vault_menu/single_sig_setup_info_view_model.dart';
 import 'package:coconut_vault/screens/vault_menu/info/name_and_icon_edit_bottom_sheet.dart';
 import 'package:coconut_vault/utils/text_utils.dart';
@@ -54,6 +55,12 @@ class _SingleSigSetupInfoScreenState extends State<SingleSigSetupInfoScreen> {
   }
 
   Future<void> _verifyBiometric(BuildContext context, PinCheckContextEnum pinCheckContext) async {
+    final authProvider = context.read<AuthProvider>();
+    if (await authProvider.isBiometricsAuthValid()) {
+      _verifySwitch(context, pinCheckContext);
+      return;
+    }
+
     MyBottomSheet.showBottomSheet_90(
       context: context,
       child: CustomLoadingOverlay(


### PR DESCRIPTION
### 변경사항
설정화면(비밀번호 설정, 비밀번호 바꾸기, 업데이트 준비) 로직 수정
feat(pin_check_screen): 기존 생체인증 로직 분리
feat(start_view_model): 앱 진입시 생체인식 > 비밀번호 순으로 확인
feat(single_sig_setup_info_screen): 니모닉 보기, 삭제하기 클릭시 생체인식 > 비밀번호 순으로 확인
feat(multisig_setup_info_screen): 삭제하기 클릭시 생체인식 > 비밀번호 순으로 확인

### 테스트 방법
어플 실행하여 테스트

### 테스트 케이스
보안 인증로직은 6가지 경우(앱 실행, 설정 화면 비밀번호 바꾸기, 설정 화면 업데이트 준비, 니모닉 보기, 삭제하기, multisig 삭제하기)에서 사용됩니다. 
|상황|인증 X, 지갑 X| 핀코드 O, 지갑 O | 핀코드, 생체인증 O, 지갑 O | 
|:-----------:|:----:|:---:|:----:|
| 앱 실행시 플로우 | X | 핀코드 | 생체인증 실패시 핀코드 |
| 설정 화면 비밀번호 바꾸기 | X(안 나옴) | 핀코드 | 생체인증 실패시 핀코드 |
| 설정 화면 업데이트 준비 | X(안 나옴) | 핀코드 | 생체인증 실패시 핀코드 |
| 니모닉 보기 | X(안 나옴) | 핀코드 | 생체인증 실패시 핀코드 |
| 삭제하기 | X(안 나옴) | 핀코드 | 생체인증 실패시 핀코드 |
| multisig 삭제하기 | X(안 나옴) | 핀코드 | 생체인증 실패시 핀코드 |

#165 