### PR TITLE
fix(qr-scanner): rename, fragmented QR scan handler, 스캔 중간에 노이즈 처리, Qr density 변경 시 처리

### DIFF
--- a/lib/screens/airgap/psbt_scanner_screen.dart
+++ b/lib/screens/airgap/psbt_scanner_screen.dart
@@ -7,7 +7,7 @@ import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/providers/sign_provider.dart';
 import 'package:coconut_vault/providers/view_model/airgap/psbt_scanner_view_model.dart';
 import 'package:coconut_vault/utils/alert_util.dart';
-import 'package:coconut_vault/widgets/animated_qr/animated_qr_scanner.dart';
+import 'package:coconut_vault/widgets/animated_qr/coconut_qr_scanner.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/bc_ur_qr_scan_data_handler.dart';
 import 'package:coconut_vault/widgets/custom_loading_overlay.dart';
 import 'package:flutter/material.dart';
@@ -160,7 +160,7 @@ class _PsbtScannerScreenState extends State<PsbtScannerScreen> {
           children: [
             Container(
                 color: CoconutColors.white,
-                child: AnimatedQrScanner(
+                child: CoconutQrScanner(
                     setQrViewController: _setQRViewController,
                     onComplete: _onCompletedScanningForBcUr,
                     onFailed: _onFailedScanning,

--- a/lib/screens/airgap/psbt_scanner_screen.dart
+++ b/lib/screens/airgap/psbt_scanner_screen.dart
@@ -83,12 +83,12 @@ class _PsbtScannerScreenState extends State<PsbtScannerScreen> {
     if (_isProcessing) return;
     _isProcessing = true;
 
-    final ur = signedPsbt as UR;
-    final cborBytes = ur.cbor;
-    final decodedCbor = cbor.decode(cborBytes) as CborBytes;
-
     String psbtBase64;
     try {
+      final ur = signedPsbt as UR;
+      final cborBytes = ur.cbor;
+      final decodedCbor = cbor.decode(cborBytes) as CborBytes;
+
       psbtBase64 = base64Encode(decodedCbor.bytes);
       _viewModel.parseBase64EncodedToPsbt(psbtBase64);
     } catch (e) {

--- a/lib/screens/airgap/psbt_scanner_screen.dart
+++ b/lib/screens/airgap/psbt_scanner_screen.dart
@@ -9,6 +9,7 @@ import 'package:coconut_vault/providers/view_model/airgap/psbt_scanner_view_mode
 import 'package:coconut_vault/utils/alert_util.dart';
 import 'package:coconut_vault/widgets/animated_qr/coconut_qr_scanner.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/bc_ur_qr_scan_data_handler.dart';
+import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
 import 'package:coconut_vault/widgets/custom_loading_overlay.dart';
 import 'package:flutter/material.dart';
 import 'package:coconut_vault/providers/wallet_provider.dart';
@@ -37,13 +38,15 @@ class _PsbtScannerScreenState extends State<PsbtScannerScreen> {
   bool isCameraActive = false;
   bool isAlreadyVibrateScanFailed = false;
   bool _isProcessing = false;
+  late IQrScanDataHandler _scanDataHandler;
 
   @override
   void initState() {
+    super.initState();
     _viewModel = PsbtScannerViewModel(Provider.of<WalletProvider>(context, listen: false),
         Provider.of<SignProvider>(context, listen: false), widget.id);
 
-    super.initState();
+    _scanDataHandler = BcUrQrScanDataHandler();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       context.loaderOverlay.show();
 
@@ -164,7 +167,7 @@ class _PsbtScannerScreenState extends State<PsbtScannerScreen> {
                     setQrViewController: _setQRViewController,
                     onComplete: _onCompletedScanningForBcUr,
                     onFailed: _onFailedScanning,
-                    qrDataHandler: BcUrQrScanDataHandler())),
+                    qrDataHandler: _scanDataHandler)),
             Padding(
               padding: const EdgeInsets.only(top: 20),
               child: CustomTooltip(

--- a/lib/widgets/animated_qr/scan_data_handler/bc_ur_qr_scan_data_handler.dart
+++ b/lib/widgets/animated_qr/scan_data_handler/bc_ur_qr_scan_data_handler.dart
@@ -1,9 +1,12 @@
 import 'package:coconut_vault/utils/logger.dart';
-import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
+import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_fragmented_qr_scan_data_handler.dart';
+import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/scan_data_handler_exceptions.dart';
 import 'package:ur/ur_decoder.dart';
 
-class BcUrQrScanDataHandler implements IQrScanDataHandler {
+class BcUrQrScanDataHandler implements IFragmentedQrScanDataHandler {
   URDecoder _urDecoder;
+  int? _sequenceLength;
+
   BcUrQrScanDataHandler() : _urDecoder = URDecoder();
 
   @override
@@ -20,21 +23,57 @@ class BcUrQrScanDataHandler implements IQrScanDataHandler {
 
   @override
   bool joinData(String data) {
-    Logger.log('--> joinData: $data');
-    return _urDecoder.receivePart(data);
+    if (_sequenceLength == null) {
+      final sequenceLength = parseSequenceLength(data);
+      if (sequenceLength == null) return false;
+      _sequenceLength = sequenceLength;
+    }
+    Logger.log('--> [QR] joinData: $data');
+    final receivePartResult = _urDecoder.receivePart(data);
+    if (!receivePartResult && validateFormat(data)) {
+      final sequenceValidationResult = validateSequenceLength(data);
+      if (!sequenceValidationResult) throw SequenceLengthMismatchException();
+    }
+    return receivePartResult;
+  }
+
+  int? parseSequenceLength(String data) {
+    try {
+      (String, List<String>) result = URDecoder.parse(data);
+      final sequenceLength = URDecoder.parseSequenceComponent(result.$2[0]).$2;
+      return sequenceLength;
+    } catch (_) {
+      return null;
+    }
   }
 
   @override
   bool validateFormat(String data) {
-    var lowered = data.toLowerCase();
-
-    // Validate URI scheme
-    return lowered.startsWith('ur:');
+    try {
+      (String, List<String>) result = URDecoder.parse(data);
+      URDecoder.parseSequenceComponent(result.$2[0]);
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 
   @override
   void reset() {
+    _sequenceLength = null;
     // 한번 Completed되면 다시 재사용 불가
     _urDecoder = URDecoder();
+  }
+
+  @override
+  int? get sequenceLength => _sequenceLength;
+
+  @override
+  bool validateSequenceLength(String data) {
+    if (_sequenceLength == null) {
+      throw SequenceLengthNotInitializedException();
+    }
+
+    return _sequenceLength == parseSequenceLength(data);
   }
 }

--- a/lib/widgets/animated_qr/scan_data_handler/i_fragmented_qr_scan_data_handler.dart
+++ b/lib/widgets/animated_qr/scan_data_handler/i_fragmented_qr_scan_data_handler.dart
@@ -1,0 +1,6 @@
+import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
+
+abstract class IFragmentedQrScanDataHandler extends IQrScanDataHandler {
+  int? get sequenceLength; // 필수
+  bool validateSequenceLength(String data);
+}

--- a/lib/widgets/animated_qr/scan_data_handler/scan_data_handler_exceptions.dart
+++ b/lib/widgets/animated_qr/scan_data_handler/scan_data_handler_exceptions.dart
@@ -1,0 +1,26 @@
+/// 잘못된 QR 포맷의 데이터가 들어왔을 때 발생.
+class InvalidQrFormatException implements Exception {
+  final String message;
+  InvalidQrFormatException([this.message = 'Invalid QR format']);
+
+  @override
+  String toString() => 'InvalidQrFormatException: $message';
+}
+
+/// 이전에 결정된 sequenceLength와 다른 값이 들어왔을 때 발생.
+class SequenceLengthMismatchException implements Exception {
+  final String message;
+  SequenceLengthMismatchException([this.message = 'Sequence length mismatch']);
+
+  @override
+  String toString() => 'SequenceLengthMismatchException: $message';
+}
+
+/// sequenceLength가 아직 초기화되지 않은 상태에서 접근했을 때 발생.
+class SequenceLengthNotInitializedException implements Exception {
+  final String message;
+  SequenceLengthNotInitializedException([this.message = 'Sequence length not initialized']);
+
+  @override
+  String toString() => 'SequenceLengthNotInitializedException: $message';
+}


### PR DESCRIPTION
현재 볼트에서 QR 스캔하는 곳은 '서명하기' 메뉴 뿐입니다.

[테스트 방법]
1. 코코넛 월렛 서명을 위한 PSBT QR 스캔 완료
2. 코코넛 월렛 서명을 위한 PSBT QR 스캔 중간에 월렛의 QR Density를 변경해도 이어서 스캔 완료
3. 코코넛 월렛 서명을 위한 PSBT QR 스캔 중간에 노이즈 값이 스캔되어도 스캔 완료
4. "처음"부터 아예 엉뚱한 QR 스캔 시 안내 프롬프트 뜸