### PR TITLE
[175] bc-ur qr scan 시 진행률 표기

### DIFF
--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -181,6 +181,9 @@ unit_bottom_sheet:
   basic_unit: "기본 단위"
   header_text: "1 BTC = 100,000,000 sats"
 
+coconut_qr_scanner:
+  reading_extra_data: "추가로 수집할 데이터를 읽고 있습니다.\n계속 스캔해 주세요."
+
 # lib/screens/setting
 app_info_screen:
   made_by_team_pow: "포우팀이 만듭니다."

--- a/lib/widgets/animated_qr/coconut_qr_scanner.dart
+++ b/lib/widgets/animated_qr/coconut_qr_scanner.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/utils/logger.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_fragmented_qr_scan_data_handler.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
@@ -32,9 +33,9 @@ class CoconutQrScanner extends StatefulWidget {
 
 class _CoconutQrScannerState extends State<CoconutQrScanner> with SingleTickerProviderStateMixin {
   final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  final ValueNotifier<double> _progressNotifier = ValueNotifier(0.0);
   final double _borderWidth = 8;
   late AnimationController _controller;
-  late Animation<double> _animation;
 
   double? _progress;
   double scannerLoadingVerticalPos = 0;
@@ -51,10 +52,6 @@ class _CoconutQrScannerState extends State<CoconutQrScanner> with SingleTickerPr
       vsync: this,
     )..repeat(reverse: true);
 
-    _animation = Tween<double>(begin: -1.0, end: 1.0).animate(CurvedAnimation(
-      parent: _controller,
-      curve: Curves.easeInOut,
-    ));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final rect = getQrViewRect();
       if (rect != null) {
@@ -73,6 +70,7 @@ class _CoconutQrScannerState extends State<CoconutQrScanner> with SingleTickerPr
 
   @override
   void dispose() {
+    _progressNotifier.dispose();
     _scanTimeoutTimer?.cancel();
     _controller.dispose();
     super.dispose();
@@ -114,6 +112,7 @@ class _CoconutQrScannerState extends State<CoconutQrScanner> with SingleTickerPr
         if (!handler.isCompleted()) {
           try {
             bool result = handler.joinData(scanData.code!);
+            _progressNotifier.value = handler.progress;
             if (!result && handler is! IFragmentedQrScanDataHandler) {
               resetScanState();
               widget.onFailed(CoconutQrScanner.qrInvalidErrorMessage);
@@ -198,33 +197,21 @@ class _CoconutQrScannerState extends State<CoconutQrScanner> with SingleTickerPr
               child: Visibility(
                 visible: _showLoadingBar,
                 child: Center(
-                  child: Container(
-                    width: MediaQuery.sizeOf(context).width,
-                    height: 4,
-                    margin: const EdgeInsets.symmetric(horizontal: 100),
-                    decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(0.2),
-                      borderRadius: BorderRadius.circular(2),
-                    ),
-                    child: (_progress != null)
-                        ? AnimatedBuilder(
-                            animation: _animation,
-                            builder: (context, child) {
-                              return Align(
-                                alignment: Alignment(_animation.value, 0),
-                                child: child,
-                              );
-                            },
-                            child: Container(
-                              width: 40,
-                              height: 4,
-                              decoration: BoxDecoration(
-                                color: Colors.white,
-                                borderRadius: BorderRadius.circular(2),
-                              ),
-                            ),
-                          )
-                        : const SizedBox.shrink(),
+                  child: ValueListenableBuilder<double>(
+                    valueListenable: _progressNotifier,
+                    builder: (context, value, _) {
+                      bool isScanningExtraData = value > 0.99;
+                      return Padding(
+                        padding: EdgeInsets.only(top: isScanningExtraData ? 24 : 0),
+                        child: Text(
+                          textAlign: TextAlign.center,
+                          isScanningExtraData
+                              ? t.coconut_qr_scanner.reading_extra_data
+                              : "${(value * 100).toStringAsFixed(1)}%",
+                          style: CoconutTypography.body1_16,
+                        ),
+                      );
+                    },
                   ),
                 ),
               ),


### PR DESCRIPTION
### 변경사항
 - 진행도 애니메이션 삭제
 - 진행률 퍼센트 표시 하다가 99% 이후 텍스트 표시

### 테스트 방법
어플 실행하여 테스트

### 테스트 시나리오
1. [월렛] 지갑 보내기 - >[월렛] 보내기 QR -> [볼트] QR 읽기에서 진행률 확인

#175 