### PR TITLE
[181] 볼트 - 비밀번호 설정

### DIFF
--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -140,6 +140,8 @@ pin_setting_screen:
   enter_again: "Confirm again"
   new_password: "Enter new password"
   keep_in_mind: "Please set a password you can definitely remember"
+  character_password_input: "Enter text password"
+  number_password_input: "Enter numeric password"
 security_self_check_screen:
   check1: "I am responsible for my private keys."
   check2: "I do not capture or photograph the mnemonic screen."

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -141,6 +141,8 @@ pin_setting_screen:
   enter_again: "다시 한번 확인할게요"
   new_password: "새로운 비밀번호를 눌러주세요"
   keep_in_mind: "반드시 기억할 수 있는 비밀번호로 설정해 주세요"
+  character_password_input: "문자 비밀번호 입력"
+  number_password_input: "숫자 비밀번호 입력"
 security_self_check_screen:
   check1: "나의 개인키는 내가 스스로 책임집니다."
   check2: "니모닉 문구 화면을 캡처하거나 촬영하지 않습니다."

--- a/lib/constants/pin_constants.dart
+++ b/lib/constants/pin_constants.dart
@@ -3,7 +3,7 @@ const kBiometricIdentifier = 'bio';
 const kDeleteBtnIdentifier = '<';
 
 // pin check constants
-const kExpectedPinLength = 4;
+const kExpectedPinLength = 6;
 const kMaxAttemptPerTurn = 3;
 const kMaxTurn = 8;
 

--- a/lib/constants/shared_preferences_keys.dart
+++ b/lib/constants/shared_preferences_keys.dart
@@ -1,6 +1,7 @@
 class SharedPrefsKeys {
   static const String hasShownStartGuide = "HAS_SHOWN_START_GUIDE";
   static const String isPinEnabled = "IS_PIN_ENABLED";
+  static const String isPinCharacter = "IS_PIN_CHARACTER";
   static const String vaultListLength = "VAULT_LIST_LENGTH";
   static const String kVaultListField = 'VAULT_LIST';
   static const String canCheckBiometrics = "CAN_CHECK_BIOMETRICS";

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -303,6 +303,7 @@ class AuthProvider extends ChangeNotifier {
       return;
     }
 
+    /// INFO: 디버그 모드일 때는 잠금 시도 실패 횟수 별 딜레이를 늘리지 않습니다.
     final unlockableDateTime = DateTime.now().add(kDebugMode
         ? const Duration(seconds: kDebugPinInputDelay)
         : Duration(minutes: kLockoutDurationsPerTurn[turn - 1]));

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -31,6 +31,10 @@ class AuthProvider extends ChangeNotifier {
   bool _isPinSet = false;
   bool get isPinSet => _isPinSet;
 
+  /// 문자 패스워드 여부
+  bool _isPinCharacter = false;
+  bool get isPinCharacter => _isPinCharacter;
+
   /// 리셋 여부
   bool _hasAlreadyRequestedBioPermission = false;
   bool get hasAlreadyRequestedBioPermission => _hasAlreadyRequestedBioPermission;
@@ -98,6 +102,7 @@ class AuthProvider extends ChangeNotifier {
 
   void setInitState() {
     _isPinSet = _sharedPrefs.getBool(SharedPrefsKeys.isPinEnabled) == true;
+    _isPinCharacter = _sharedPrefs.getBool(SharedPrefsKeys.isPinCharacter) == true;
     _loadBiometricState();
     _loadUnlockState();
     notifyListeners();
@@ -256,8 +261,8 @@ class AuthProvider extends ChangeNotifier {
     return false;
   }
 
-  /// 비밀번호 저장
-  Future<void> savePin(String pin) async {
+  /// 비밀번호 6자리, 유형 저장
+  Future<void> savePin(String pin, bool isCharacter) async {
     if (_isBiometricEnabled && _canCheckBiometrics && !_isPinSet) {
       _isBiometricEnabled = true;
       _sharedPrefs.setBool(SharedPrefsKeys.isBiometricEnabled, true);
@@ -266,7 +271,9 @@ class AuthProvider extends ChangeNotifier {
     String hashed = hashString(pin);
     await _storageService.write(key: SecureStorageKeys.kVaultPin, value: hashed);
     _isPinSet = true;
+    _isPinCharacter = isCharacter;
     _sharedPrefs.setBool(SharedPrefsKeys.isPinEnabled, true);
+    _sharedPrefs.setBool(SharedPrefsKeys.isPinCharacter, isCharacter);
     notifyListeners();
   }
 

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -261,7 +261,7 @@ class AuthProvider extends ChangeNotifier {
     return false;
   }
 
-  /// 비밀번호 6자리, 유형 저장
+  /// 비밀번호 및 유형 저장
   Future<void> savePin(String pin, bool isCharacter) async {
     if (_isBiometricEnabled && _canCheckBiometrics && !_isPinSet) {
       _isBiometricEnabled = true;

--- a/lib/screens/common/pin_check_screen.dart
+++ b/lib/screens/common/pin_check_screen.dart
@@ -216,10 +216,6 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
           _errorMessage = _isLastChanceToTry
               ? t.errors.remaining_times_away_from_reset_error(count: remainingTimes)
               : t.errors.pin_incorrect_with_remaining_attempts_error(count: remainingTimes);
-          if (kDebugMode) {
-            _errorMessage +=
-                ' (디버깅중 ${_authProvider.currentTurn} / ${_authProvider.currentAttemptInTurn})';
-          }
         });
       } else {
         vibrateMedium();

--- a/lib/screens/common/pin_check_screen.dart
+++ b/lib/screens/common/pin_check_screen.dart
@@ -131,7 +131,7 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
     }
   }
 
-  void _onKeyTap(String value) async {
+  void _onKeyTap(String value, bool isCharacter) async {
     if (_isUnlockDisabled == null ||
         _isUnlockDisabled == true ||
         _isAppLaunched && _authProvider.isPermanantlyLocked) return;
@@ -142,7 +142,7 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
     }
 
     setState(() {
-      if (value == kDeleteBtnIdentifier) {
+      if (value == kDeleteBtnIdentifier && !isCharacter) {
         if (_pin.isNotEmpty) {
           _pin = _pin.substring(0, _pin.length - 1);
         }
@@ -350,6 +350,7 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
     Logger.log(
         '--> PinInputScreen isPermanantlyLocked: ${_authProvider.isPermanantlyLocked} / isUnlockDisabled: $_isUnlockDisabled');
     return PinInputScreen(
+      canChangePinType: false,
       appBarVisible: _isAppLaunched ? false : true,
       title: _isAppLaunched ? '' : t.pin_check_screen.enter_password,
       initOptionVisible: _isAppLaunched,
@@ -362,6 +363,12 @@ class _PinCheckScreenState extends State<PinCheckScreen> with WidgetsBindingObse
       },
       onBackPressed: () {
         Navigator.pop(context);
+      },
+      onPinClear: () {
+        setState(() {
+          _pin = '';
+          _errorMessage = '';
+        });
       },
       onReset: isOnReset ? _showResetDialog : null,
       step: 0,

--- a/lib/screens/common/pin_input_screen.dart
+++ b/lib/screens/common/pin_input_screen.dart
@@ -1,10 +1,10 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_vault/constants/pin_constants.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/providers/auth_provider.dart';
 import 'package:coconut_vault/widgets/pin/pin_length_toggle_button.dart';
 import 'package:flutter/material.dart';
 import 'package:coconut_vault/widgets/button/key_button.dart';
-import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import '../../widgets/pin/pin_box.dart';
@@ -89,7 +89,13 @@ class PinInputScreenState extends State<PinInputScreen> {
         _characterController.text = "";
       }
     }
+
     _previousCharacterText = currentText;
+    // 비밀번호 확인에서 사용하는 경우를 위해 미리 정리한다.
+    if (currentText.length == kExpectedPinLength) {
+      _previousCharacterText = "";
+      _characterController.text = "";
+    }
   }
 
   void _togglePinType() {
@@ -99,6 +105,7 @@ class PinInputScreenState extends State<PinInputScreen> {
       _characterFocusNode.requestFocus();
     }
     widget.onPinClear();
+    _characterController.clear();
     setState(() {});
   }
 
@@ -133,12 +140,8 @@ class PinInputScreenState extends State<PinInputScreen> {
               child: widget.descriptionTextWidget ?? const Text(''),
             ),
             const SizedBox(height: 10),
-            GestureDetector(
-              onTap: () {
-                if (_pinType == PinType.number) return;
-                _characterFocusNode.requestFocus();
-              },
-              child: Row(
+            if (_pinType == PinType.number)
+              Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   PinBox(isSet: widget.pin.isNotEmpty, disabled: widget.disabled),
@@ -154,21 +157,26 @@ class PinInputScreenState extends State<PinInputScreen> {
                   PinBox(isSet: widget.pin.length > 5, disabled: widget.disabled),
                 ],
               ),
-            ),
-            SizedBox(
-              width: 0,
-              height: 0,
-              child: TextField(
-                controller: _characterController,
-                focusNode: _characterFocusNode,
-                keyboardType: TextInputType.text,
-                inputFormatters: [
-                  FilteringTextInputFormatter.allow(
-                    RegExp(r'[ -~×÷<>]'), // 기본 ASCII + × + ÷
-                  ),
-                ],
+            if (_pinType == PinType.character)
+              SizedBox(
+                width: 235,
+                child: CoconutTextField(
+                  padding: const EdgeInsets.fromLTRB(16, 15, 16, 15),
+                  borderRadius: 14,
+                  backgroundColor: CoconutColors.gray150,
+                  placeholderColor: Colors.transparent,
+                  textAlign: TextAlign.center,
+                  maxLength: 6,
+                  maxLines: 1,
+                  isLengthVisible: false,
+                  isVisibleBorder: false,
+                  errorText: null,
+                  descriptionText: null,
+                  controller: _characterController,
+                  focusNode: _characterFocusNode,
+                  onChanged: (text) {},
+                ),
               ),
-            ),
             if (widget.canChangePinType && widget.step == 0)
               Padding(
                 padding: const EdgeInsets.only(top: 16),

--- a/lib/screens/common/pin_input_screen.dart
+++ b/lib/screens/common/pin_input_screen.dart
@@ -195,7 +195,7 @@ class PinInputScreenState extends State<PinInputScreen> {
                 visible: widget.initOptionVisible,
                 replacement: Container(),
                 child: Padding(
-                    padding: const EdgeInsets.only(bottom: 60.0),
+                    padding: EdgeInsets.only(bottom: _characterFocusNode.hasFocus ? 30 : 60),
                     child: GestureDetector(
                       onTap: () {
                         widget.onReset?.call();

--- a/lib/screens/common/pin_input_screen.dart
+++ b/lib/screens/common/pin_input_screen.dart
@@ -1,7 +1,11 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
+import 'package:coconut_vault/providers/auth_provider.dart';
+import 'package:coconut_vault/widgets/pin/pin_length_toggle_button.dart';
 import 'package:flutter/material.dart';
 import 'package:coconut_vault/widgets/button/key_button.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 
 import '../../widgets/pin/pin_box.dart';
 
@@ -10,10 +14,11 @@ class PinInputScreen extends StatefulWidget {
   final Text? descriptionTextWidget;
   final String pin;
   final String errorMessage;
-  final void Function(String) onKeyTap;
+  final void Function(String, bool) onKeyTap;
   final List<String> pinShuffleNumbers;
   final Function? onReset;
   final VoidCallback onClosePressed;
+  final VoidCallback onPinClear;
   final VoidCallback? onBackPressed;
   final int step;
   final bool appBarVisible;
@@ -21,6 +26,7 @@ class PinInputScreen extends StatefulWidget {
   final bool lastChance;
   final String? lastChanceMessage;
   final bool disabled;
+  final bool canChangePinType;
 
   const PinInputScreen(
       {super.key,
@@ -30,9 +36,11 @@ class PinInputScreen extends StatefulWidget {
       required this.onKeyTap,
       required this.pinShuffleNumbers,
       required this.onClosePressed,
+      required this.onPinClear,
       this.onReset,
       this.onBackPressed,
       required this.step,
+      required this.canChangePinType,
       this.appBarVisible = true,
       this.initOptionVisible = false,
       this.descriptionTextWidget,
@@ -45,9 +53,59 @@ class PinInputScreen extends StatefulWidget {
 }
 
 class PinInputScreenState extends State<PinInputScreen> {
+  final FocusNode _characterFocusNode = FocusNode();
+  final TextEditingController _characterController = TextEditingController();
+  String _previousCharacterText = "";
+  PinType _pinType = PinType.number;
+
+  @override
+  void initState() {
+    super.initState();
+    _characterController.addListener(_characterTextListener);
+    if (context.read<AuthProvider>().isPinCharacter) {
+      _pinType = PinType.character;
+      _characterFocusNode.requestFocus();
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _characterFocusNode.dispose();
+    _characterController.dispose();
+  }
+
+  void _characterTextListener() {
+    // 문자가 입력된 경우와 삭제된 경우를 인식한다.
+    String currentText = _characterController.text;
+    if (currentText.length > _previousCharacterText.length) {
+      String lastInserted = currentText.substring(_previousCharacterText.length);
+      widget.onKeyTap(lastInserted, true);
+    } else if (currentText.length < _previousCharacterText.length) {
+      widget.onKeyTap('<', false);
+      // 삭제 버튼을 꾹 누른 경우에 대한 처리
+      if (currentText.isEmpty) {
+        _previousCharacterText = "";
+        _characterController.text = "";
+      }
+    }
+    _previousCharacterText = currentText;
+  }
+
+  void _togglePinType() {
+    _pinType = _pinType == PinType.character ? PinType.number : PinType.character;
+    FocusScope.of(context).unfocus();
+    if (_pinType == PinType.character) {
+      _characterFocusNode.requestFocus();
+    }
+    widget.onPinClear();
+    setState(() {});
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       backgroundColor: Colors.transparent,
       appBar: widget.appBarVisible
           ? CoconutAppBar.build(
@@ -75,18 +133,50 @@ class PinInputScreenState extends State<PinInputScreen> {
               child: widget.descriptionTextWidget ?? const Text(''),
             ),
             const SizedBox(height: 10),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                PinBox(isSet: widget.pin.isNotEmpty, disabled: widget.disabled),
-                const SizedBox(width: 8),
-                PinBox(isSet: widget.pin.length > 1, disabled: widget.disabled),
-                const SizedBox(width: 8),
-                PinBox(isSet: widget.pin.length > 2, disabled: widget.disabled),
-                const SizedBox(width: 8),
-                PinBox(isSet: widget.pin.length > 3, disabled: widget.disabled),
-              ],
+            GestureDetector(
+              onTap: () {
+                if (_pinType == PinType.number) return;
+                _characterFocusNode.requestFocus();
+              },
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  PinBox(isSet: widget.pin.isNotEmpty, disabled: widget.disabled),
+                  const SizedBox(width: 8),
+                  PinBox(isSet: widget.pin.length > 1, disabled: widget.disabled),
+                  const SizedBox(width: 8),
+                  PinBox(isSet: widget.pin.length > 2, disabled: widget.disabled),
+                  const SizedBox(width: 8),
+                  PinBox(isSet: widget.pin.length > 3, disabled: widget.disabled),
+                  const SizedBox(width: 8),
+                  PinBox(isSet: widget.pin.length > 4, disabled: widget.disabled),
+                  const SizedBox(width: 8),
+                  PinBox(isSet: widget.pin.length > 5, disabled: widget.disabled),
+                ],
+              ),
             ),
+            SizedBox(
+              width: 0,
+              height: 0,
+              child: TextField(
+                controller: _characterController,
+                focusNode: _characterFocusNode,
+                keyboardType: TextInputType.text,
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(
+                    RegExp(r'[ -~×÷<>]'), // 기본 ASCII + × + ÷
+                  ),
+                ],
+              ),
+            ),
+            if (widget.canChangePinType && widget.step == 0)
+              Padding(
+                padding: const EdgeInsets.only(top: 16),
+                child: SizedBox(
+                    height: 40,
+                    child: PinTypeToggleButton(
+                        isActive: true, currentPinType: _pinType, onToggle: _togglePinType)),
+              ),
             const SizedBox(height: 16),
             Text(
               widget.errorMessage,
@@ -103,23 +193,29 @@ class PinInputScreenState extends State<PinInputScreen> {
             ),
             const SizedBox(height: 40),
             Expanded(
-              child: Align(
-                alignment: Alignment.bottomCenter,
-                child: GridView.count(
-                  crossAxisCount: 3,
-                  childAspectRatio: 2,
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  children: widget.pinShuffleNumbers.map((key) {
-                    return Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: KeyButton(
-                        keyValue: key,
-                        onKeyTap: widget.onKeyTap,
-                        disabled: widget.disabled,
-                      ),
-                    );
-                  }).toList(),
+              child: IgnorePointer(
+                ignoring: _pinType == PinType.character,
+                child: Opacity(
+                  opacity: _pinType == PinType.number ? 1.0 : 0.0,
+                  child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: GridView.count(
+                      crossAxisCount: 3,
+                      childAspectRatio: 2,
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      children: widget.pinShuffleNumbers.map((key) {
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: KeyButton(
+                            keyValue: key,
+                            onKeyTap: widget.onKeyTap,
+                            disabled: widget.disabled,
+                          ),
+                        );
+                      }).toList(),
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/lib/screens/common/pin_input_screen.dart
+++ b/lib/screens/common/pin_input_screen.dart
@@ -109,108 +109,102 @@ class PinInputScreenState extends State<PinInputScreen> {
               isBottom: widget.step == 0,
             )
           : null,
-      body: GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onTap: () {
-          FocusScope.of(context).unfocus(); // 키보드 내리기
-        },
-        child: SafeArea(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              SizedBox(height: widget.initOptionVisible ? 60 : 24),
-              Text(
-                widget.title,
-                style: CoconutTypography.body1_16_Bold,
-                textAlign: TextAlign.center,
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            SizedBox(height: widget.initOptionVisible ? 60 : 24),
+            Text(
+              widget.title,
+              style: CoconutTypography.body1_16_Bold,
+              textAlign: TextAlign.center,
+            ),
+            CoconutLayout.spacing_300h,
+            Align(
+              alignment: Alignment.center,
+              child: widget.descriptionTextWidget ?? const Text(''),
+            ),
+            CoconutLayout.spacing_200h,
+            SizedBox(
+              height: 56,
+              child: _pinType == PinType.number ? _buildNumberInput() : _buildCharacterInput(),
+            ),
+            if (widget.canChangePinType && widget.step == 0)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: SizedBox(
+                    height: 40,
+                    child: PinTypeToggleButton(
+                        isActive: true, currentPinType: _pinType, onToggle: _togglePinType)),
               ),
-              CoconutLayout.spacing_300h,
-              Align(
-                alignment: Alignment.center,
-                child: widget.descriptionTextWidget ?? const Text(''),
-              ),
-              CoconutLayout.spacing_200h,
-              SizedBox(
-                height: 56,
-                child: _pinType == PinType.number ? _buildNumberInput() : _buildCharacterInput(),
-              ),
-              if (widget.canChangePinType && widget.step == 0)
-                Padding(
-                  padding: const EdgeInsets.only(top: 12),
-                  child: SizedBox(
-                      height: 40,
-                      child: PinTypeToggleButton(
-                          isActive: true, currentPinType: _pinType, onToggle: _togglePinType)),
-                ),
-              CoconutLayout.spacing_200h,
-              Text(
-                widget.errorMessage,
+            CoconutLayout.spacing_200h,
+            Text(
+              widget.errorMessage,
+              style: CoconutTypography.body3_12.setColor(CoconutColors.warningText),
+              textAlign: TextAlign.center,
+            ),
+            Visibility(
+              visible: widget.lastChance,
+              child: Text(
+                widget.lastChanceMessage ?? '',
                 style: CoconutTypography.body3_12.setColor(CoconutColors.warningText),
                 textAlign: TextAlign.center,
               ),
-              Visibility(
-                visible: widget.lastChance,
-                child: Text(
-                  widget.lastChanceMessage ?? '',
-                  style: CoconutTypography.body3_12.setColor(CoconutColors.warningText),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-              const SizedBox(height: 40),
-              Expanded(
-                child: IgnorePointer(
-                  ignoring: _pinType == PinType.character,
-                  child: Opacity(
-                    opacity: _pinType == PinType.number ? 1.0 : 0.0,
-                    child: Align(
-                      alignment: Alignment.bottomCenter,
-                      child: GridView.count(
-                        crossAxisCount: 3,
-                        childAspectRatio: 2,
-                        shrinkWrap: true,
-                        physics: const NeverScrollableScrollPhysics(),
-                        children: widget.pinShuffleNumbers.map((key) {
-                          return Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 16),
-                            child: KeyButton(
-                              keyValue: key,
-                              onKeyTap: widget.onKeyTap,
-                              disabled: widget.disabled,
-                            ),
-                          );
-                        }).toList(),
-                      ),
+            ),
+            const SizedBox(height: 40),
+            Expanded(
+              child: IgnorePointer(
+                ignoring: _pinType == PinType.character,
+                child: Opacity(
+                  opacity: _pinType == PinType.number ? 1.0 : 0.0,
+                  child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: GridView.count(
+                      crossAxisCount: 3,
+                      childAspectRatio: 2,
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      children: widget.pinShuffleNumbers.map((key) {
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: KeyButton(
+                            keyValue: key,
+                            onKeyTap: widget.onKeyTap,
+                            disabled: widget.disabled,
+                          ),
+                        );
+                      }).toList(),
                     ),
                   ),
                 ),
               ),
-              SizedBox(
-                  height: widget.initOptionVisible
-                      ? 60
-                      : MediaQuery.sizeOf(context).height <= 640
-                          ? 30
-                          : 100),
-              Visibility(
-                visible: widget.initOptionVisible,
-                replacement: Container(),
-                child: Padding(
-                    padding: EdgeInsets.only(bottom: _characterFocusNode.hasFocus ? 30 : 60),
-                    child: GestureDetector(
-                      onTap: () {
-                        widget.onReset?.call();
-                      },
-                      child: Text(
-                        t.forgot_password,
-                        style: CoconutTypography.body2_14_Bold.setColor(
-                          CoconutColors.black.withOpacity(0.5),
-                        ),
-                        textAlign: TextAlign.center,
+            ),
+            SizedBox(
+                height: widget.initOptionVisible
+                    ? 60
+                    : MediaQuery.sizeOf(context).height <= 640
+                        ? 30
+                        : 100),
+            Visibility(
+              visible: widget.initOptionVisible,
+              replacement: Container(),
+              child: Padding(
+                  padding: EdgeInsets.only(bottom: _characterFocusNode.hasFocus ? 30 : 60),
+                  child: GestureDetector(
+                    onTap: () {
+                      widget.onReset?.call();
+                    },
+                    child: Text(
+                      t.forgot_password,
+                      style: CoconutTypography.body2_14_Bold.setColor(
+                        CoconutColors.black.withOpacity(0.5),
                       ),
-                    )),
-              ),
-            ],
-          ),
+                      textAlign: TextAlign.center,
+                    ),
+                  )),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/common/pin_input_screen.dart
+++ b/lib/screens/common/pin_input_screen.dart
@@ -109,102 +109,108 @@ class PinInputScreenState extends State<PinInputScreen> {
               isBottom: widget.step == 0,
             )
           : null,
-      body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            SizedBox(height: widget.initOptionVisible ? 60 : 24),
-            Text(
-              widget.title,
-              style: CoconutTypography.body1_16_Bold,
-              textAlign: TextAlign.center,
-            ),
-            CoconutLayout.spacing_300h,
-            Align(
-              alignment: Alignment.center,
-              child: widget.descriptionTextWidget ?? const Text(''),
-            ),
-            CoconutLayout.spacing_200h,
-            SizedBox(
-              height: 56,
-              child: _pinType == PinType.number ? _buildNumberInput() : _buildCharacterInput(),
-            ),
-            if (widget.canChangePinType && widget.step == 0)
-              Padding(
-                padding: const EdgeInsets.only(top: 12),
-                child: SizedBox(
-                    height: 40,
-                    child: PinTypeToggleButton(
-                        isActive: true, currentPinType: _pinType, onToggle: _togglePinType)),
+      body: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onTap: () {
+          FocusScope.of(context).unfocus(); // 키보드 내리기
+        },
+        child: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              SizedBox(height: widget.initOptionVisible ? 60 : 24),
+              Text(
+                widget.title,
+                style: CoconutTypography.body1_16_Bold,
+                textAlign: TextAlign.center,
               ),
-            CoconutLayout.spacing_200h,
-            Text(
-              widget.errorMessage,
-              style: CoconutTypography.body3_12.setColor(CoconutColors.warningText),
-              textAlign: TextAlign.center,
-            ),
-            Visibility(
-              visible: widget.lastChance,
-              child: Text(
-                widget.lastChanceMessage ?? '',
+              CoconutLayout.spacing_300h,
+              Align(
+                alignment: Alignment.center,
+                child: widget.descriptionTextWidget ?? const Text(''),
+              ),
+              CoconutLayout.spacing_200h,
+              SizedBox(
+                height: 56,
+                child: _pinType == PinType.number ? _buildNumberInput() : _buildCharacterInput(),
+              ),
+              if (widget.canChangePinType && widget.step == 0)
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: SizedBox(
+                      height: 40,
+                      child: PinTypeToggleButton(
+                          isActive: true, currentPinType: _pinType, onToggle: _togglePinType)),
+                ),
+              CoconutLayout.spacing_200h,
+              Text(
+                widget.errorMessage,
                 style: CoconutTypography.body3_12.setColor(CoconutColors.warningText),
                 textAlign: TextAlign.center,
               ),
-            ),
-            const SizedBox(height: 40),
-            Expanded(
-              child: IgnorePointer(
-                ignoring: _pinType == PinType.character,
-                child: Opacity(
-                  opacity: _pinType == PinType.number ? 1.0 : 0.0,
-                  child: Align(
-                    alignment: Alignment.bottomCenter,
-                    child: GridView.count(
-                      crossAxisCount: 3,
-                      childAspectRatio: 2,
-                      shrinkWrap: true,
-                      physics: const NeverScrollableScrollPhysics(),
-                      children: widget.pinShuffleNumbers.map((key) {
-                        return Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 16),
-                          child: KeyButton(
-                            keyValue: key,
-                            onKeyTap: widget.onKeyTap,
-                            disabled: widget.disabled,
-                          ),
-                        );
-                      }).toList(),
+              Visibility(
+                visible: widget.lastChance,
+                child: Text(
+                  widget.lastChanceMessage ?? '',
+                  style: CoconutTypography.body3_12.setColor(CoconutColors.warningText),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              const SizedBox(height: 40),
+              Expanded(
+                child: IgnorePointer(
+                  ignoring: _pinType == PinType.character,
+                  child: Opacity(
+                    opacity: _pinType == PinType.number ? 1.0 : 0.0,
+                    child: Align(
+                      alignment: Alignment.bottomCenter,
+                      child: GridView.count(
+                        crossAxisCount: 3,
+                        childAspectRatio: 2,
+                        shrinkWrap: true,
+                        physics: const NeverScrollableScrollPhysics(),
+                        children: widget.pinShuffleNumbers.map((key) {
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            child: KeyButton(
+                              keyValue: key,
+                              onKeyTap: widget.onKeyTap,
+                              disabled: widget.disabled,
+                            ),
+                          );
+                        }).toList(),
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-            SizedBox(
-                height: widget.initOptionVisible
-                    ? 60
-                    : MediaQuery.sizeOf(context).height <= 640
-                        ? 30
-                        : 100),
-            Visibility(
-              visible: widget.initOptionVisible,
-              replacement: Container(),
-              child: Padding(
-                  padding: const EdgeInsets.only(bottom: 60.0),
-                  child: GestureDetector(
-                    onTap: () {
-                      widget.onReset?.call();
-                    },
-                    child: Text(
-                      t.forgot_password,
-                      style: CoconutTypography.body2_14_Bold.setColor(
-                        CoconutColors.black.withOpacity(0.5),
+              SizedBox(
+                  height: widget.initOptionVisible
+                      ? 60
+                      : MediaQuery.sizeOf(context).height <= 640
+                          ? 30
+                          : 100),
+              Visibility(
+                visible: widget.initOptionVisible,
+                replacement: Container(),
+                child: Padding(
+                    padding: const EdgeInsets.only(bottom: 60.0),
+                    child: GestureDetector(
+                      onTap: () {
+                        widget.onReset?.call();
+                      },
+                      child: Text(
+                        t.forgot_password,
+                        style: CoconutTypography.body2_14_Bold.setColor(
+                          CoconutColors.black.withOpacity(0.5),
+                        ),
+                        textAlign: TextAlign.center,
                       ),
-                      textAlign: TextAlign.center,
-                    ),
-                  )),
-            ),
-          ],
+                    )),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -247,6 +253,7 @@ class PinInputScreenState extends State<PinInputScreen> {
         focusNode: _characterFocusNode,
         onChanged: (text) {},
         textInputAction: TextInputAction.done,
+        enabled: !widget.disabled,
         onEditingComplete: () {
           // 문자 입력 모드에서 'Done' 버튼을 누르는 경우 다음 단계로 이동
           if (_pinType == PinType.character) {

--- a/lib/screens/settings/pin_setting_screen.dart
+++ b/lib/screens/settings/pin_setting_screen.dart
@@ -69,11 +69,11 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
     return isSamePin;
   }
 
-  void _onKeyTap(String value) async {
+  void _onKeyTap(String value, bool isCharacter) async {
     // if (value != '<' && value != 'bio' && value != '') vibrateShort();
 
     if (step == 0) {
-      if (value == kDeleteBtnIdentifier) {
+      if (value == kDeleteBtnIdentifier && !isCharacter) {
         if (pin.isNotEmpty) {
           setState(() {
             pin = pin.substring(0, pin.length - 1);
@@ -105,7 +105,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
       }
     } else if (step == 1) {
       setState(() {
-        if (value == kDeleteBtnIdentifier) {
+        if (value == kDeleteBtnIdentifier && !isCharacter) {
           if (pinConfirm.isNotEmpty) {
             pinConfirm = pinConfirm.substring(0, pinConfirm.length - 1);
           }
@@ -134,14 +134,13 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
           await _authProvider.authenticateWithBiometrics(context: context, isSaved: true);
         }
 
-        _finishPinSetting();
+        _finishPinSetting(isCharacter);
       }
     }
   }
 
-  void _finishPinSetting() async {
+  void _finishPinSetting(bool isCharacter) async {
     vibrateLight();
-
     showGeneralDialog(
       context: context,
       barrierDismissible: false,
@@ -170,7 +169,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
 
     await Future.delayed(const Duration(seconds: 3));
     widget.onComplete?.call();
-    await _authProvider.savePin(pinConfirm);
+    await _authProvider.savePin(pinConfirm, isCharacter);
 
     if (!mounted) {
       return;
@@ -238,6 +237,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
     }
 
     return PinInputScreen(
+        canChangePinType: true,
         title: step == 0 ? t.pin_setting_screen.new_password : t.pin_setting_screen.enter_again,
         descriptionTextWidget: Text.rich(
           TextSpan(
@@ -262,6 +262,14 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
                   errorMessage = '';
                 });
               },
+        onPinClear: () {
+          if (step == 0) {
+            pin = '';
+          } else {
+            pinConfirm = '';
+          }
+          setState(() {});
+        },
         onBackPressed: () {
           setState(() {
             if (widget.greetingVisible) {

--- a/lib/screens/settings/pin_setting_screen.dart
+++ b/lib/screens/settings/pin_setting_screen.dart
@@ -134,16 +134,21 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
 
   /// 비밀번호 일치 여부 확인 후 저장
   /// 비밀번호 최초 설정 시 생체 인증 사용 여부 확인
-  void _finalizePinSetup() {
+  Future<void> _finalizePinSetup() async {
     if (pin != pinConfirm) {
       errorMessage = t.errors.pin_incorrect_error;
       pinConfirm = '';
-      _shuffledPinNumbers = _authProvider.getShuffledNumberList(isPinSettingContext: true);
+      if (_currentPinType == PinType.number) {
+        _shuffledPinNumbers = _authProvider.getShuffledNumberList(isPinSettingContext: true);
+      }
+      setState(() {});
       vibrateMediumDouble();
       return;
     }
 
-    errorMessage = '';
+    setState(() {
+      errorMessage = '';
+    });
 
     // 생체 인증 사용 여부 확인
     bool isPinSet = SharedPrefsRepository().getBool(SharedPrefsKeys.isPinEnabled) ?? false;
@@ -151,11 +156,11 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
         _authProvider.canCheckBiometrics &&
         !_authProvider.hasAlreadyRequestedBioPermission &&
         mounted) {
-      _authProvider.authenticateWithBiometrics(context: context, isSaved: true);
+      await _authProvider.authenticateWithBiometrics(context: context, isSaved: true);
     }
 
     // 비밀번호 저장 후 화면 이동
-    _savePin();
+    await _savePin();
   }
 
   // 숫자 모드 PIN 입력 처리
@@ -197,7 +202,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
     }
   }
 
-  void _savePin() async {
+  Future<void> _savePin() async {
     vibrateLight();
     showGeneralDialog(
       context: context,

--- a/lib/screens/settings/pin_setting_screen.dart
+++ b/lib/screens/settings/pin_setting_screen.dart
@@ -5,6 +5,7 @@ import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/constants/shared_preferences_keys.dart';
 import 'package:coconut_vault/providers/auth_provider.dart';
 import 'package:coconut_vault/repository/shared_preferences_repository.dart';
+import 'package:coconut_vault/widgets/pin/pin_length_toggle_button.dart';
 import 'package:flutter/material.dart';
 import 'package:coconut_vault/utils/vibration_util.dart';
 import 'package:coconut_vault/widgets/animated_dialog.dart';
@@ -29,6 +30,7 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
   late String pin;
   late String pinConfirm;
   late String errorMessage;
+  PinType _currentPinType = PinType.number;
 
   late AuthProvider _authProvider;
   late List<String> _shuffledPinNumbers;
@@ -43,6 +45,8 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
 
     _authProvider = Provider.of<AuthProvider>(context, listen: false);
     _shuffledPinNumbers = _authProvider.getShuffledNumberList(isPinSettingContext: true);
+
+    _currentPinType = _authProvider.isPinCharacter ? PinType.character : PinType.number;
   }
 
   void returnToBackSequence(String message, {bool isError = false, bool firstSequence = false}) {
@@ -69,11 +73,92 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
     return isSamePin;
   }
 
-  void _onKeyTap(String value, bool isCharacter) async {
-    // if (value != '<' && value != 'bio' && value != '') vibrateShort();
+  // 입력 모드 변경 핸들러 추가: 입력 모드가 변경되면 입력값 초기화
+  void _onPinTypeChanged(PinType newPinType) {
+    setState(() {
+      _currentPinType = newPinType;
+      pin = '';
+      pinConfirm = '';
+      errorMessage = '';
+      if (step == 1) {
+        step = 0;
+      }
+    });
+  }
 
+  void _onKeyTap(String value) async {
+    if (_currentPinType == PinType.character) {
+      // 문자 입력 모드에서 'Done' 버튼을 누르는 경우
+      _onPressDoneKey(value);
+    } else {
+      _onKeyTapNumber(value);
+    }
+  }
+
+  void _onPressDoneKey(String value) {
     if (step == 0) {
-      if (value == kDeleteBtnIdentifier && !isCharacter) {
+      pin = value;
+
+      if (pin.isNotEmpty) {
+        _proceedToNextStep();
+      }
+    } else {
+      pinConfirm = value;
+
+      if (pinConfirm.isNotEmpty) {
+        _verifyPin();
+      }
+    }
+  }
+
+  void _proceedToNextStep() async {
+    try {
+      bool isAlreadyUsingPin = await _comparePin(pin);
+
+      if (isAlreadyUsingPin) {
+        returnToBackSequence(t.errors.duplicate_pin_error, firstSequence: true);
+        return;
+      }
+    } catch (error) {
+      returnToBackSequence(t.errors.pin_processing_error, isError: true);
+      return;
+    }
+    setState(() {
+      step = 1;
+      errorMessage = '';
+      if (_currentPinType == PinType.number) {
+        _shuffledPinNumbers = _authProvider.getShuffledNumberList(isPinSettingContext: true);
+      }
+    });
+  }
+
+  void _verifyPin() {
+    if (pin != pinConfirm) {
+      errorMessage = t.errors.pin_incorrect_error;
+      pinConfirm = '';
+      _shuffledPinNumbers = _authProvider.getShuffledNumberList(isPinSettingContext: true);
+      vibrateMediumDouble();
+      return;
+    }
+
+    errorMessage = '';
+
+    /// 최초 비밀번호 설정시에 생체 인증 사용 여부 확인
+    bool isPinSet = SharedPrefsRepository().getBool(SharedPrefsKeys.isPinEnabled) ?? false;
+    if (!isPinSet &&
+        _authProvider.canCheckBiometrics &&
+        !_authProvider.hasAlreadyRequestedBioPermission &&
+        mounted) {
+      _authProvider.authenticateWithBiometrics(context: context, isSaved: true);
+    }
+
+    _finishPinSetting(_currentPinType == PinType.character ? true : false);
+  }
+
+  // 숫자 모드 PIN 입력 처리
+  void _onKeyTapNumber(String value) async {
+    if (step == 0) {
+      if (value == kDeleteBtnIdentifier) {
         if (pin.isNotEmpty) {
           setState(() {
             pin = pin.substring(0, pin.length - 1);
@@ -83,58 +168,28 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
         setState(() {
           pin += value;
         });
+        vibrateLight();
       }
 
       if (pin.length == kExpectedPinLength) {
-        try {
-          bool isAlreadyUsingPin = await _comparePin(pin);
-
-          if (isAlreadyUsingPin) {
-            returnToBackSequence(t.errors.duplicate_pin_error, firstSequence: true);
-            return;
-          }
-        } catch (error) {
-          returnToBackSequence(t.errors.pin_processing_error, isError: true);
-          return;
+        _proceedToNextStep();
+      }
+    } else {
+      if (value == kDeleteBtnIdentifier) {
+        if (pinConfirm.isNotEmpty) {
+          setState(() {
+            pinConfirm = pinConfirm.substring(0, pinConfirm.length - 1);
+          });
         }
+      } else if (pinConfirm.length < kExpectedPinLength) {
         setState(() {
-          step = 1;
-          errorMessage = '';
-          _shuffledPinNumbers = _authProvider.getShuffledNumberList(isPinSettingContext: true);
+          pinConfirm += value;
+          vibrateLight();
         });
       }
-    } else if (step == 1) {
-      setState(() {
-        if (value == kDeleteBtnIdentifier && !isCharacter) {
-          if (pinConfirm.isNotEmpty) {
-            pinConfirm = pinConfirm.substring(0, pinConfirm.length - 1);
-          }
-        } else if (pinConfirm.length < kExpectedPinLength) {
-          pinConfirm += value;
-        }
-      });
 
       if (pinConfirm.length == kExpectedPinLength) {
-        if (pin != pinConfirm) {
-          errorMessage = t.errors.pin_incorrect_error;
-          pinConfirm = '';
-          _shuffledPinNumbers = _authProvider.getShuffledNumberList(isPinSettingContext: true);
-          vibrateMediumDouble();
-          return;
-        }
-
-        errorMessage = '';
-
-        /// 최초 비밀번호 설정시에 생체 인증 사용 여부 확인
-        bool isPinSet = SharedPrefsRepository().getBool(SharedPrefsKeys.isPinEnabled) ?? false;
-        if (!isPinSet &&
-            _authProvider.canCheckBiometrics &&
-            !_authProvider.hasAlreadyRequestedBioPermission &&
-            mounted) {
-          await _authProvider.authenticateWithBiometrics(context: context, isSaved: true);
-        }
-
-        _finishPinSetting(isCharacter);
+        _verifyPin();
       }
     }
   }
@@ -249,6 +304,8 @@ class _PinSettingScreenState extends State<PinSettingScreen> {
         pin: step == 0 ? pin : pinConfirm,
         errorMessage: errorMessage,
         onKeyTap: _onKeyTap,
+        onPinTypeChanged: _onPinTypeChanged,
+        pinType: _currentPinType,
         pinShuffleNumbers: _shuffledPinNumbers,
         onClosePressed: step == 0
             ? () {

--- a/lib/screens/vault_menu/info/multisig_setup_info_screen.dart
+++ b/lib/screens/vault_menu/info/multisig_setup_info_screen.dart
@@ -53,7 +53,7 @@ class _MultisigSetupInfoScreenState extends State<MultisigSetupInfoScreen> {
     });
   }
 
-  Future _verifyBiometric(
+  Future _authenticateWithBiometricOrPin(
     BuildContext context,
   ) async {
     void onComplete() {
@@ -63,7 +63,7 @@ class _MultisigSetupInfoScreenState extends State<MultisigSetupInfoScreen> {
     }
 
     final authProvider = context.read<AuthProvider>();
-    if (await authProvider.isBiometricsAuthValid()) {
+    if (await authProvider.isBiometricsAuthValid() && context.mounted) {
       onComplete();
       return;
     }
@@ -387,11 +387,8 @@ class _MultisigSetupInfoScreenState extends State<MultisigSetupInfoScreen> {
                   title: t.confirm,
                   content: t.alert.confirm_deletion(name: name),
                   onConfirmPressed: () async {
-                    context.loaderOverlay.show();
-                    await Future.delayed(const Duration(seconds: 1));
                     if (context.mounted) {
-                      _verifyBiometric(context);
-                      context.loaderOverlay.hide();
+                      _authenticateWithBiometricOrPin(context);
                     }
                   },
                 );

--- a/lib/screens/vault_menu/info/single_sig_setup_info_screen.dart
+++ b/lib/screens/vault_menu/info/single_sig_setup_info_screen.dart
@@ -55,7 +55,8 @@ class _SingleSigSetupInfoScreenState extends State<SingleSigSetupInfoScreen> {
 
   Future<void> _verifyBiometric(BuildContext context, PinCheckContextEnum pinCheckContext) async {
     final authProvider = context.read<AuthProvider>();
-    if (await authProvider.isBiometricsAuthValid()) {
+
+    if (await authProvider.isBiometricsAuthValid() && context.mounted) {
       _verifySwitch(context, pinCheckContext);
       return;
     }

--- a/lib/widgets/button/key_button.dart
+++ b/lib/widgets/button/key_button.dart
@@ -9,7 +9,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 class KeyButton extends StatefulWidget {
   final String keyValue;
-  final void Function(String, bool) onKeyTap;
+  final void Function(String) onKeyTap;
   final bool disabled;
 
   const KeyButton({
@@ -72,7 +72,7 @@ class _KeyButtonState extends State<KeyButton> {
   Widget build(BuildContext context) {
     return GestureDetector(
         onTap: () {
-          widget.onKeyTap(widget.keyValue, false);
+          widget.onKeyTap(widget.keyValue);
         },
         onTapDown: (_) {
           setState(() {

--- a/lib/widgets/button/key_button.dart
+++ b/lib/widgets/button/key_button.dart
@@ -9,7 +9,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 class KeyButton extends StatefulWidget {
   final String keyValue;
-  final ValueChanged<String> onKeyTap;
+  final void Function(String, bool) onKeyTap;
   final bool disabled;
 
   const KeyButton({
@@ -72,7 +72,7 @@ class _KeyButtonState extends State<KeyButton> {
   Widget build(BuildContext context) {
     return GestureDetector(
         onTap: () {
-          widget.onKeyTap(widget.keyValue);
+          widget.onKeyTap(widget.keyValue, false);
         },
         onTapDown: (_) {
           setState(() {

--- a/lib/widgets/pin/pin_box.dart
+++ b/lib/widgets/pin/pin_box.dart
@@ -22,11 +22,11 @@ class PinBox extends StatelessWidget {
         ),
         child: isSet
             ? Padding(
-                padding: const EdgeInsets.all(Sizes.size12),
+                padding: const EdgeInsets.all(10),
                 child: SvgPicture.asset(
                   'assets/svg/coconut-${NetworkType.currentNetworkType.isTestnet ? "regtest" : "mainnet"}.svg',
                   colorFilter: ColorFilter.mode(
-                      disabled ? CoconutColors.black.withOpacity(0.06) : CoconutColors.black,
+                      disabled ? CoconutColors.black.withOpacity(0.06) : CoconutColors.gray800,
                       BlendMode.srcIn),
                 ),
               )

--- a/lib/widgets/pin/pin_box.dart
+++ b/lib/widgets/pin/pin_box.dart
@@ -12,8 +12,8 @@ class PinBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-        width: 50,
-        height: 50,
+        width: 40,
+        height: 40,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(14),
           color: disabled

--- a/lib/widgets/pin/pin_length_toggle_button.dart
+++ b/lib/widgets/pin/pin_length_toggle_button.dart
@@ -1,0 +1,40 @@
+import 'package:coconut_vault/localization/strings.g.dart';
+import 'package:flutter/material.dart';
+import 'package:coconut_design_system/coconut_design_system.dart';
+
+enum PinType {
+  number,
+  character,
+}
+
+class PinTypeToggleButton extends StatelessWidget {
+  final PinType currentPinType;
+  final VoidCallback onToggle;
+  final bool isActive;
+
+  const PinTypeToggleButton({
+    super.key,
+    required this.currentPinType,
+    required this.onToggle,
+    required this.isActive,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 40.0),
+      child: CoconutButton(
+          width: 180,
+          padding: const EdgeInsets.symmetric(horizontal: Sizes.size12, vertical: Sizes.size8),
+          isActive: isActive,
+          onPressed: onToggle,
+          text: currentPinType == PinType.character
+              ? t.pin_setting_screen.number_password_input
+              : t.pin_setting_screen.character_password_input,
+          pressedBackgroundColor: CoconutColors.gray800,
+          backgroundColor: CoconutColors.gray350,
+          buttonType: CoconutButtonType.outlined,
+          textStyle: CoconutTypography.body2_14.setColor(CoconutColors.black)),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,7 +75,7 @@ dependencies:
   coconut_lib: ^0.10.4
   coconut_design_system:
     git: 
-      url: https://github.com/noncelab/coconut_design_system.git
+      url: https://github.com/ella-noncelab/coconut_design_system.git
       ref: main
   cbor: ^6.3.5
   ur:


### PR DESCRIPTION
### 변경사항
 - 비밀번호 6자리로 변경
 - 비밀번호 타입 추가(문자, 숫자)

### 테스트 방법
어플 실행하여 테스트

<image src="https://github.com/user-attachments/assets/be4bec6c-070a-411f-8d8a-59879c90ebc7" width="250px" /> 
<image src="https://github.com/user-attachments/assets/be5a6f68-22cb-4705-97fb-3547ff6ebfa2" width="250px" /> 

### 테스트 케이스
- [x] 비밀번호 설정 화면에서는 [비밀번호 유형] 변경 가능, 비밀번호 입력 화면에서는 변경 불가.
- [x] 0. 초기 진입 화면 
- [ ] 1. 설정 페이지 - 비밀번호 설정하기, 비밀번호 바꾸기, 업데이트 준비 
- [ ] 2. 복구 화면
- [ ] 3. 멀티시그/싱글시그 사인 
- [ ] 4. 볼트 정보 화면  - 삭제하기, 니모닉 보기.

#181 

### 📚Etc
기존에 사용하던 유저들의 비밀번호 4자리에 대한 마이그레이션은 생각하지 않는다. (패스프레이즈 업그레이드시 재설치 유도할 예정)
