### PR TITLE
[237] 안전 저장 모드로 변경 시 패스프레이즈 설정값 Off

### DIFF
--- a/lib/providers/visibility_provider.dart
+++ b/lib/providers/visibility_provider.dart
@@ -211,6 +211,7 @@ class VisibilityProvider extends ChangeNotifier {
       setAdvancedMode(true);
       SharedPrefsRepository().deleteSharedPrefsWithKey(SharedPrefsKeys.vaultListLength);
     } else {
+      setAdvancedMode(false);
       SharedPrefsRepository().setInt(SharedPrefsKeys.vaultListLength, _walletCount);
     }
     _isSigningOnlyMode = isSigningOnlyMode;


### PR DESCRIPTION
안전 저장 모드 -> 패스프레이즈 사용 -> 서명 전용 모드 -> 안전 저장 모드로 변경 시 패스프레이즈 사용 여부가 켜져 있음.

## 주요 변경 사항
- 서명 전용 모드에서 안전 저장 모드로 변경 시 패스프레이즈 사용 여부 담당하는 bool 값 false로 변경

## 2. 이슈 번호
#237 