### PR TITLE
[Feat] Signer bsms Data Handler

### DIFF
--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -87,8 +87,6 @@ sign_required: "Click the button to sign"
 sign_required_amount: 
   one: "$n signature required"
   other: "$n signatures required"
-move_to_qr_screen: "Move to QR Screen"
-move_to_qr_screen_description: "Generate QR to sign in key-holding vault."
 
 wallet_delete_failed: "No wallets to delete"
 wallet_delete_failed_description: "No wallets are currently saved, so deletion isn’t necessary"
@@ -525,6 +523,12 @@ hardware_wallet_type:
 multisig_creation_options_screen:
   quorum: "Create a new wallet"
   bsms: "Have wallet backup data"
+
+multisig_sign_screen:
+  loading_overlay: "Signing from another device..."
+  dialog:
+    title: 'Prepare $name'
+    description: 'To sign with $name, you need to set up in advance. Would you like to go to the setup screen?'
 
 confirm_importing_screen:
   guide1: "Please verify that "

--- a/assets/i18n/jp.i18n.yaml
+++ b/assets/i18n/jp.i18n.yaml
@@ -87,8 +87,6 @@ sign_required: "ボタンを押して署名してください"
 sign_required_amount:
   one: "$n個の署名が必要"
   other: "$n個の署名が必要"
-move_to_qr_screen: "QR画面に移動"
-move_to_qr_screen_description: "キー保持ボルトで署名するためのQRを生成"
 
 wallet_delete_failed: "削除するウォレットはありません"
 wallet_delete_failed_description: "現在、保存されているウォレットがないため、削除する必要はありません。"
@@ -526,6 +524,12 @@ hardware_wallet_type:
 multisig_creation_options_screen:
   quorum: "新しいウォレットを作成"
   bsms: "ウォレットのバックアップデータあり"
+
+multisig_sign_screen:
+  loading_overlay: "別のデバイスから署名を開始します..."
+  dialog:
+    title: '$name 準備'
+    description: '$nameで署名するには、事前に設定が必要です。設定画面に移動しますか？'
 
 confirm_importing_screen:
   guide1: "他のボルトから"

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -87,8 +87,6 @@ sign_required: "버튼을 눌러 서명해 주세요"
 sign_required_amount: 
   one: "$n개의 서명이 필요해요"
   other: "$n개의 서명이 필요해요"
-move_to_qr_screen: "QR 코드 화면으로 이동"
-move_to_qr_screen_description: "키가 있는 볼트에서 서명하기 위해 QR을 생성합니다."
 
 wallet_delete_failed: "삭제할 지갑 없음"
 wallet_delete_failed_description: "현재 저장된 지갑이 없어 삭제할 필요가 없어요"
@@ -526,6 +524,12 @@ hardware_wallet_type:
 multisig_creation_options_screen:
   quorum: "새로운 지갑을 만들게요"
   bsms: "지갑 백업 데이터가 있어요"
+
+multisig_sign_screen:
+  loading_overlay: "다른 기기에서 서명을 시작합니다..."
+  dialog:
+    title: '$name 준비하기'
+    description: '$name로 서명을 하기 위해 사전 설정이 필요합니다. 사전 설정 화면으로 가시겠어요?'
 
 confirm_importing_screen:
   guide1: "다른 볼트에서 가져온 "

--- a/lib/enums/wallet_enums.dart
+++ b/lib/enums/wallet_enums.dart
@@ -16,22 +16,22 @@ enum WalletType {
   }
 }
 
-enum HarewareWalletType { vault, keystone, seesigner, jade, coldcard, krux }
+enum HardwareWalletType { vault, keystone, seesigner, jade, coldcard, krux }
 
-extension HarewareWalletTypeExtension on HarewareWalletType {
+extension HarewareWalletTypeExtension on HardwareWalletType {
   String get displayName {
     switch (this) {
-      case HarewareWalletType.vault:
+      case HardwareWalletType.vault:
         return t.hardware_wallet_type.vault;
-      case HarewareWalletType.keystone:
+      case HardwareWalletType.keystone:
         return t.hardware_wallet_type.keystone;
-      case HarewareWalletType.seesigner:
+      case HardwareWalletType.seesigner:
         return t.hardware_wallet_type.seesigner;
-      case HarewareWalletType.jade:
+      case HardwareWalletType.jade:
         return t.hardware_wallet_type.jade;
-      case HarewareWalletType.coldcard:
+      case HardwareWalletType.coldcard:
         return t.hardware_wallet_type.coldcard;
-      case HarewareWalletType.krux:
+      case HardwareWalletType.krux:
         return t.hardware_wallet_type.krux;
     }
   }

--- a/lib/providers/view_model/airgap/multisig_sign_view_model.dart
+++ b/lib/providers/view_model/airgap/multisig_sign_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_lib/coconut_lib.dart';
+import 'package:coconut_vault/enums/wallet_enums.dart';
 import 'package:coconut_vault/isolates/sign_isolates.dart';
 import 'package:coconut_vault/model/multisig/multisig_signer.dart';
 import 'package:coconut_vault/model/multisig/multisig_vault_list_item.dart';
@@ -117,5 +118,16 @@ class MultisigSignViewModel extends ChangeNotifier {
     _signProvider.resetRecipientAmounts();
     _signProvider.resetSendingAmount();
     _signProvider.resetSignedPsbt();
+  }
+
+  // TODO: signers[index]의 hww type 가져오기
+  HardwareWalletType? getSignerHwwType(int index) {
+    // return _vaultListItem.signers[index].hardwareWalletType ?? HarewareWalletType.vault;
+    return null;
+  }
+
+  // TODO: signers[index]의 hww type에 따라 다른 정보를 반환하도록 구현
+  String getMultisigInfoQrData(int index) {
+    return '';
   }
 }

--- a/lib/screens/airgap/multisig_info_qr_code_screen.dart
+++ b/lib/screens/airgap/multisig_info_qr_code_screen.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_vault/enums/wallet_enums.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/providers/visibility_provider.dart';
 import 'package:coconut_vault/services/blockchain_commons/ur_type.dart';
@@ -8,18 +9,27 @@ import 'package:coconut_vault/widgets/custom_tooltip.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class SignerQrBottomSheet extends StatefulWidget {
+class MultisigQrCodeViewScreen extends StatefulWidget {
   final String multisigName;
   final String keyIndex;
   final String signedRawTx;
+  final HardwareWalletType hardwareWalletType;
+  final String qrData;
 
-  const SignerQrBottomSheet({super.key, required this.multisigName, required this.keyIndex, required this.signedRawTx});
+  const MultisigQrCodeViewScreen({
+    super.key,
+    required this.multisigName,
+    required this.keyIndex,
+    required this.signedRawTx,
+    required this.hardwareWalletType,
+    required this.qrData,
+  });
 
   @override
-  State<SignerQrBottomSheet> createState() => _SignerQrBottomSheetState();
+  State<MultisigQrCodeViewScreen> createState() => _MultisigQrCodeViewScreenState();
 }
 
-class _SignerQrBottomSheetState extends State<SignerQrBottomSheet> {
+class _MultisigQrCodeViewScreenState extends State<MultisigQrCodeViewScreen> {
   late VisibilityProvider _visibilityProvider;
 
   bool _isEnglish = true;

--- a/lib/screens/airgap/multisig_psbt_qr_code_screen.dart
+++ b/lib/screens/airgap/multisig_psbt_qr_code_screen.dart
@@ -1,0 +1,119 @@
+import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_vault/enums/wallet_enums.dart';
+import 'package:coconut_vault/localization/strings.g.dart';
+import 'package:coconut_vault/providers/visibility_provider.dart';
+import 'package:coconut_vault/services/blockchain_commons/ur_type.dart';
+import 'package:coconut_vault/widgets/animated_qr/animated_qr_view.dart';
+import 'package:coconut_vault/widgets/animated_qr/view_data_handler/bc_ur_qr_view_handler.dart';
+import 'package:coconut_vault/widgets/custom_tooltip.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class PsbtQrCodeViewScreen extends StatefulWidget {
+  final String multisigName;
+  final String keyIndex;
+  final String signedRawTx;
+  final HardwareWalletType hardwareWalletType;
+
+  const PsbtQrCodeViewScreen({
+    super.key,
+    required this.multisigName,
+    required this.keyIndex,
+    required this.signedRawTx,
+    required this.hardwareWalletType,
+  });
+
+  @override
+  State<PsbtQrCodeViewScreen> createState() => _PsbtQrCodeViewScreenState();
+}
+
+class _PsbtQrCodeViewScreenState extends State<PsbtQrCodeViewScreen> {
+  late VisibilityProvider _visibilityProvider;
+
+  bool _isEnglish = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _visibilityProvider = Provider.of<VisibilityProvider>(context, listen: false);
+    _isEnglish = _visibilityProvider.language == 'en';
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: CoconutBorder.defaultRadius,
+      child: Scaffold(
+        backgroundColor: CoconutColors.white,
+        appBar: CoconutAppBar.build(context: context, title: t.signer_qr_bottom_sheet.title, isBottom: true),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Container(
+              width: double.infinity,
+              color: CoconutColors.white,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  CustomTooltip.buildInfoTooltip(
+                    context,
+                    richText: RichText(
+                      text: TextSpan(style: CoconutTypography.body2_14, children: _getTooltipRichText()),
+                    ),
+                  ),
+                  const SizedBox(height: 40),
+                  Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: CoconutBoxDecoration.shadowBoxDecoration,
+                    child: AnimatedQrView(
+                      qrViewDataHandler: BcUrQrViewHandler(widget.signedRawTx, UrType.cryptoPsbt),
+                      qrSize: MediaQuery.of(context).size.width * 0.8,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<TextSpan> _getTooltipRichText() {
+    final textStyle = CoconutTypography.body2_14.copyWith(height: 1.2, color: CoconutColors.black);
+    final textStyleNumberBold = CoconutTypography.body1_16_Bold.copyWith(height: 1.2, color: CoconutColors.black);
+    final textStyleBold = CoconutTypography.body2_14_Bold.copyWith(height: 1.2, color: CoconutColors.black);
+
+    if (_isEnglish) {
+      return [
+        TextSpan(text: '[1] ', style: textStyleNumberBold),
+        TextSpan(text: t.signer_qr_bottom_sheet.text1, style: textStyle),
+        TextSpan(text: widget.keyIndex, style: textStyleBold),
+        TextSpan(text: ',', style: textStyle),
+        const TextSpan(text: '\n'),
+        TextSpan(text: '1. ', style: textStyle),
+        TextSpan(text: t.signer_qr_bottom_sheet.select, style: textStyle),
+        TextSpan(text: t.signer_qr_bottom_sheet.text2, style: textStyleBold),
+        const TextSpan(text: '\n'),
+        TextSpan(text: '2. ', style: textStyle),
+        TextSpan(text: t.signer_qr_bottom_sheet.text3, style: textStyle),
+      ];
+    }
+
+    return [
+      TextSpan(text: '[1] ${widget.keyIndex}', style: textStyleNumberBold),
+      TextSpan(text: t.signer_qr_bottom_sheet.text1, style: textStyle),
+      const TextSpan(text: '\n'),
+      TextSpan(text: '1. ', style: textStyle),
+      TextSpan(text: t.signer_qr_bottom_sheet.text2, style: textStyleBold),
+      TextSpan(text: t.signer_qr_bottom_sheet.select, style: textStyle),
+      const TextSpan(text: '\n'),
+      TextSpan(text: '2. ', style: textStyle),
+      TextSpan(text: t.signer_qr_bottom_sheet.text3, style: textStyleBold),
+    ];
+  }
+}

--- a/lib/screens/vault_creation/multisig/signer_assignment_screen.dart
+++ b/lib/screens/vault_creation/multisig/signer_assignment_screen.dart
@@ -451,7 +451,7 @@ class _SignerAssignmentScreenState extends State<SignerAssignmentScreen> {
       physics: const ClampingScrollPhysics(),
       enableSingleChildScroll: false,
       hideAppBar: true,
-      child: const SignerBsmsScannerScreen(harewareWalletType: HarewareWalletType.vault),
+      child: const SignerBsmsScannerScreen(harewareWalletType: HardwareWalletType.vault),
     );
 
     if (externalImported != null) {
@@ -494,7 +494,7 @@ class _SignerAssignmentScreenState extends State<SignerAssignmentScreen> {
               enableSingleChildScroll: false,
               hideAppBar: true,
               child: const SignerBsmsScannerScreen(
-                harewareWalletType: HarewareWalletType.coldcard,
+                harewareWalletType: HardwareWalletType.coldcard,
               ), // TODO: 선택한 결과에 맞게 harewareWalletType 변경하기
             );
 

--- a/lib/screens/vault_creation/multisig/signer_bsms_scanner_screen.dart
+++ b/lib/screens/vault_creation/multisig/signer_bsms_scanner_screen.dart
@@ -15,8 +15,8 @@ import 'package:mobile_scanner/mobile_scanner.dart';
 // Signer bsms 및 descriptor 정보를 스캔합니다.
 class SignerBsmsScannerScreen extends StatefulWidget {
   final int? id;
-  final HarewareWalletType? harewareWalletType;
-  const SignerBsmsScannerScreen({super.key, this.id, this.harewareWalletType = HarewareWalletType.vault});
+  final HardwareWalletType? harewareWalletType;
+  const SignerBsmsScannerScreen({super.key, this.id, this.harewareWalletType = HardwareWalletType.vault});
 
   @override
   State<SignerBsmsScannerScreen> createState() => _SignerBsmsScannerScreenState();
@@ -78,19 +78,19 @@ class _SignerBsmsScannerScreenState extends BsmsScannerBase<SignerBsmsScannerScr
       Logger.log('--> SignerBsmsScannerScreen: result: $result');
 
       switch (widget.harewareWalletType) {
-        case HarewareWalletType.vault:
+        case HardwareWalletType.vault:
           Bsms.parseSigner(scanData);
           scanResult = scanData;
           break;
-        case HarewareWalletType.keystone:
-        case HarewareWalletType.jade:
+        case HardwareWalletType.keystone:
+        case HardwareWalletType.jade:
           scanResult = MultisigNormalizer.fromUrResult(result as Map<dynamic, dynamic>);
           break;
-        case HarewareWalletType.coldcard:
+        case HardwareWalletType.coldcard:
           scanResult = MultisigNormalizer.fromBbQrResult(result);
           break;
-        case HarewareWalletType.seesigner:
-        case HarewareWalletType.krux:
+        case HardwareWalletType.seesigner:
+        case HardwareWalletType.krux:
           scanResult = MultisigNormalizer.fromTextResult(result);
           break;
         default:

--- a/lib/widgets/animated_qr/scan_data_handler/signer_bsms_qr_data_handler.dart
+++ b/lib/widgets/animated_qr/scan_data_handler/signer_bsms_qr_data_handler.dart
@@ -6,31 +6,31 @@ import 'package:coconut_vault/utils/ur_bytes_converter.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
 
 class SignerBsmsQrDataHandler implements IQrScanDataHandler {
-  final HarewareWalletType? harewareWalletType;
+  final HardwareWalletType? harewareWalletType;
   URDecoder _urDecoder;
   BbQrDecoder _bbQrDecoder;
 
   StringBuffer? _textBuffer;
 
-  SignerBsmsQrDataHandler({this.harewareWalletType = HarewareWalletType.vault})
+  SignerBsmsQrDataHandler({this.harewareWalletType = HardwareWalletType.vault})
     : _urDecoder = URDecoder(),
       _bbQrDecoder = BbQrDecoder();
 
   @override
   dynamic get result {
     switch (harewareWalletType) {
-      case HarewareWalletType.keystone:
-      case HarewareWalletType.jade:
+      case HardwareWalletType.keystone:
+      case HardwareWalletType.jade:
         return UrBytesConverter.convertToMap(_urDecoder.result);
-      case HarewareWalletType.coldcard:
+      case HardwareWalletType.coldcard:
         if (!_bbQrDecoder.isComplete) return null;
         if (_bbQrDecoder.dataType == 'J') {
           return _bbQrDecoder.parseJson();
         }
         return _bbQrDecoder.getCombinedText();
-      case HarewareWalletType.seesigner:
-      case HarewareWalletType.krux:
-      case HarewareWalletType.vault:
+      case HardwareWalletType.seesigner:
+      case HardwareWalletType.krux:
+      case HardwareWalletType.vault:
         return _textBuffer?.toString();
       default:
         return null;
@@ -40,14 +40,14 @@ class SignerBsmsQrDataHandler implements IQrScanDataHandler {
   @override
   double get progress {
     switch (harewareWalletType) {
-      case HarewareWalletType.keystone:
-      case HarewareWalletType.jade:
+      case HardwareWalletType.keystone:
+      case HardwareWalletType.jade:
         return _urDecoder.estimatedPercentComplete();
-      case HarewareWalletType.coldcard:
+      case HardwareWalletType.coldcard:
         return _bbQrDecoder.progress;
-      case HarewareWalletType.seesigner:
-      case HarewareWalletType.krux:
-      case HarewareWalletType.vault:
+      case HardwareWalletType.seesigner:
+      case HardwareWalletType.krux:
+      case HardwareWalletType.vault:
         return isCompleted() ? 1.0 : 0.0;
       default:
         return 0.0;
@@ -61,14 +61,14 @@ class SignerBsmsQrDataHandler implements IQrScanDataHandler {
     }
 
     switch (harewareWalletType) {
-      case HarewareWalletType.keystone:
-      case HarewareWalletType.jade:
+      case HardwareWalletType.keystone:
+      case HardwareWalletType.jade:
         return _urDecoder.receivePart(data);
-      case HarewareWalletType.coldcard:
+      case HardwareWalletType.coldcard:
         return _bbQrDecoder.receivePart(data);
-      case HarewareWalletType.seesigner:
-      case HarewareWalletType.krux:
-      case HarewareWalletType.vault:
+      case HardwareWalletType.seesigner:
+      case HardwareWalletType.krux:
+      case HardwareWalletType.vault:
         _textBuffer ??= StringBuffer();
         _textBuffer!.write(data);
         return true;
@@ -83,14 +83,14 @@ class SignerBsmsQrDataHandler implements IQrScanDataHandler {
 
     try {
       switch (harewareWalletType) {
-        case HarewareWalletType.keystone:
-        case HarewareWalletType.jade:
+        case HardwareWalletType.keystone:
+        case HardwareWalletType.jade:
           return normalized.startsWith('ur:crypto-account/');
-        case HarewareWalletType.coldcard:
+        case HardwareWalletType.coldcard:
           return normalized.startsWith('b\$');
-        case HarewareWalletType.vault:
-        case HarewareWalletType.seesigner:
-        case HarewareWalletType.krux:
+        case HardwareWalletType.vault:
+        case HardwareWalletType.seesigner:
+        case HardwareWalletType.krux:
           return _isValidSignerDescriptor(normalized);
         default:
           return false;
@@ -103,14 +103,14 @@ class SignerBsmsQrDataHandler implements IQrScanDataHandler {
   @override
   bool isCompleted() {
     switch (harewareWalletType) {
-      case HarewareWalletType.keystone:
-      case HarewareWalletType.jade:
+      case HardwareWalletType.keystone:
+      case HardwareWalletType.jade:
         return _urDecoder.isComplete();
-      case HarewareWalletType.coldcard:
+      case HardwareWalletType.coldcard:
         return _bbQrDecoder.isComplete;
-      case HarewareWalletType.vault:
-      case HarewareWalletType.seesigner:
-      case HarewareWalletType.krux:
+      case HardwareWalletType.vault:
+      case HardwareWalletType.seesigner:
+      case HardwareWalletType.krux:
         return _textBuffer != null && _textBuffer!.isNotEmpty;
       default:
         return false;


### PR DESCRIPTION
### 내용 
- [리팩토링] signer_assignment_screen 
  - 키 종류 선택 바텀싯 메뉴 위젯 리팩토링
  - hww 선택 바텀싯 컨테이너 임시 생성: signer_assignment_screen 에서 임의로 hww type enum을 지정하면 signer_bsms_scanner_screen.dart의 앱 타이틀과 핸들러 타입이 그에 맞게 지정됨
- signer_bsms_qr_data_handler.dart 
  - hww으로부터의 스캔 데이터 핸들러 구현