### PR TITLE
[272] 홈 화면 다중 서명 지갑 가져오기 버튼 기능 수정

### DIFF
--- a/lib/screens/home/vault_home_screen.dart
+++ b/lib/screens/home/vault_home_screen.dart
@@ -482,11 +482,15 @@ class _VaultHomeScreenState extends State<VaultHomeScreen> with TickerProviderSt
                 Expanded(
                   child: _buildActionItemButton(
                     // 다중서명 지갑 가져오기 버튼
-                    isActive: true,
+                    isActive: _viewModel.isVaultsLoaded,
                     text: t.vault_home_screen.action_items.import_multisig_wallet,
                     iconAssetPath: 'assets/svg/two-keys.svg',
                     iconPadding: const EdgeInsets.only(right: 15, bottom: 9),
                     onPressed: () {
+                      if (!_viewModel.isVaultsLoaded) {
+                        return;
+                      }
+
                       Navigator.pushNamed(context, AppRoutes.coordinatorBsmsConfigScanner);
                     },
                   ),


### PR DESCRIPTION
# 주요 변경 사항

- 홈 화면에서 다중 서명 지갑 가져오기 버튼 활성화 조건 항상 가능하도록 변경
- 다중 서명 지갑 가져오기 버튼 클릭 시 생성되던 바텀시트 제거
- 다중 서명 지갑 가져오기 버튼 클릭 시 coordinatorbsmsconfigscanner 스캔 화면으로 이동

# 특이사항
현재 272 브랜치에서 붙여넣기 아이콘 svg 및 fixedbottombutton 부분이 남아있음.
이미 247에서 수정된 상태이므로 머지할 때 주의 필요

### 이슈 번호
#272 