### PR TITLE
시드QR로 키 추가 상황에서 패스프레이즈 입력 실패 오류

### DIFF
--- a/lib/screens/vault_creation/single_sig/seed_qr_confirmation_screen.dart
+++ b/lib/screens/vault_creation/single_sig/seed_qr_confirmation_screen.dart
@@ -150,7 +150,7 @@ class _SeedQrConfirmationScreenState extends State<SeedQrConfirmationScreen> {
                   text: t.next,
                   isActive: _usePassphrase ? _passphrase.isNotEmpty && !_isWarningVisible : true && !_isWarningVisible,
                   backgroundColor: CoconutColors.black,
-                  onButtonClicked: () => _handleNextButton(context),
+                  onButtonClicked: () => _handleNextButton(),
                   gradientPadding: const EdgeInsets.only(left: 16, right: 16, bottom: 40, top: 140),
                 ),
                 WarningWidget(
@@ -169,9 +169,8 @@ class _SeedQrConfirmationScreenState extends State<SeedQrConfirmationScreen> {
     );
   }
 
-  Future<void> _handleNextButton(BuildContext context) async {
+  Future<void> _handleNextButton() async {
     try {
-      _passphraseFocusNode.unfocus();
       final secret = widget.scannedData;
       final passphrase = utf8.encode(_usePassphrase ? _passphrase : '');
       final externalSigner = widget.externalSigner;


### PR DESCRIPTION
멀티 시그 지갑 키 추가 상황에서 시드 QR 스캔 후
패스프레이즈를 signerbsms 지갑과 다르게 입력 시
'동일한 지갑이 아니에요' 팝업은 작동하지만 로딩 overlay가 종료되지 않는 현상
-> 키보드 unfocus 코드 작업시간이 loaderOverlay.hide 되는 부분과 충돌이 일어나 발생

# 주요 변경 사항
패스프레이즈 입력이 성공 시 다음 화면으로 넘어가고
패스프레이즈 입력이 실패했을 경우 키보드 unfocus를 할 이유가 없으므로
unfocus 코드를 제거하여 해결 (니모닉 입력으로 키 추가 시에도 unfocus 코드가 없었기에 동일하게 변경)