### PR TITLE
지갑 내보내기 QR에서 로딩 UI 에러 문제

### DIFF
--- a/lib/widgets/animated_qr/animated_qr_view.dart
+++ b/lib/widgets/animated_qr/animated_qr_view.dart
@@ -62,13 +62,9 @@ class _AnimatedQrViewState extends State<AnimatedQrView> {
 
     _timer = Timer.periodic(Duration(milliseconds: widget.milliSeconds), (timer) {
       final next = widget.qrViewDataHandler.nextPart();
-      final int estimatedBits = next.runes.fold<int>(0, (prev, c) => prev + c.bitLength);
-
-      if (estimatedBits <= _maxBits) {
-        setState(() {
-          _qrData = next;
-        });
-      }
+      setState(() {
+        _qrData = next;
+      });
     });
   }
 


### PR DESCRIPTION
다중서명지갑 - 지갑 내보내기 - 보기 전용 앱으로 내보내기 - '스패로우/넌척' 선택 - QR영역에 Message Loading Indicator가 계속 떠있음
원인: 로딩 위젯 생성 조건에 데이터 길이 포함 -> 스패로우, 넌척의 경우 데이터 길이가 길어 해당 조건 만족 -> 로딩 ui 문제 지속 발생

## 변경사항
- 로딩 화면이 뜨는 조건을 데이터가 없을 때(_qrData.isEmpty)로 한정
- 초과 데이터 렌더링 로직 분리: 데이터의 크기가 설정된 제한(maxBits 또는 maxCharsForVersion)을 초과하는 경우, 에러나 로딩으로 처리하지 않고 QrVersions.auto를 사용하여 QR 코드를 정상적으로 렌더링하도록 변경