### PR TITLE
[292] coordinator bsms qr view model refactor

### DIFF
--- a/lib/providers/view_model/wallet_info/coordinator_bsms_qr_view_model.dart
+++ b/lib/providers/view_model/wallet_info/coordinator_bsms_qr_view_model.dart
@@ -10,7 +10,7 @@ import 'package:coconut_vault/packages/bc-ur-dart/lib/cbor_lite.dart';
 import 'package:ur/ur.dart';
 import 'package:ur/ur_encoder.dart';
 
-enum CoordinatorViewMode { coconutVaultOnly, backupAll }
+enum CoordinatorViewMode { shareWithOtherVault, all }
 
 class CoordinatorBsmsQrViewModel extends ChangeNotifier {
   late String qrData;
@@ -28,7 +28,7 @@ class CoordinatorBsmsQrViewModel extends ChangeNotifier {
 
     _generateBsmsJson(vaultListItem);
 
-    if (mode == CoordinatorViewMode.backupAll) {
+    if (mode == CoordinatorViewMode.all) {
       _generateAllFormats(vaultListItem);
     }
 

--- a/lib/screens/wallet_info/multisig_menu/backup_wallet_data_screen.dart
+++ b/lib/screens/wallet_info/multisig_menu/backup_wallet_data_screen.dart
@@ -19,7 +19,7 @@ class BackupWalletDataScreen extends StatelessWidget {
           (context) => CoordinatorBsmsQrViewModel(
             Provider.of<WalletProvider>(context, listen: false),
             id,
-            mode: CoordinatorViewMode.backupAll,
+            mode: CoordinatorViewMode.all,
           ),
       child: Consumer<CoordinatorBsmsQrViewModel>(
         builder: (context, viewModel, child) {

--- a/lib/screens/wallet_info/multisig_menu/coordinator_bsms_qr_screen.dart
+++ b/lib/screens/wallet_info/multisig_menu/coordinator_bsms_qr_screen.dart
@@ -19,7 +19,7 @@ class CoordinatorBsmsQrScreen extends StatelessWidget {
           (context) => CoordinatorBsmsQrViewModel(
             Provider.of<WalletProvider>(context, listen: false),
             id,
-            mode: CoordinatorViewMode.coconutVaultOnly,
+            mode: CoordinatorViewMode.shareWithOtherVault,
           ),
       child: Consumer<CoordinatorBsmsQrViewModel>(
         builder: (context, viewModel, child) {


### PR DESCRIPTION
coordinator_bsms_qr_view_model을 두 screen(coordinator_bsms_qr_screen, backup_wallet_data_screen)에서 사용 중
하나의 screen에서 모든 데이터를 생성하는 것이 비효율적인 상황

## 변경사항
coordinator_bsms_qr_view_model에 모드 적용
-coconutVaultOnly : 다른 볼트로 공유하기 화면에 사용되는 qr만 생성
-backupAll : 지갑 데이터 백업하기 화면에 사용되는 qr 모두 생성
