### PR TITLE
[293] 카메라 권한 설정 없을 때 팝업

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,7 +44,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "onl.coconut.vault"
-    compileSdk 35
+    compileSdk 36
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/android/app/src/main/kotlin/onl/coconut/vault/MainActivity.kt
+++ b/android/app/src/main/kotlin/onl/coconut/vault/MainActivity.kt
@@ -18,12 +18,13 @@ import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
 import android.content.pm.ActivityInfo
+import android.net.Uri
 
 import android.util.Log
 
 class MainActivity: FlutterFragmentActivity() {
     private val CHANNEL = "onl.coconut.vault/os"
-    private val SYSTEM_SETTINGS_CHANNEL = "system_settings"
+    private val SYSTEM_SETTINGS_CHANNEL = "app-settings"
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -88,6 +89,17 @@ class MainActivity: FlutterFragmentActivity() {
                         result.success(null)
                     } catch (e: Exception) {
                         result.error("OPEN_SECURITY_SETTINGS_ERROR", e.message, null)
+                    }
+                }
+                "openAppSettings" -> {
+                    try {
+                        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                        intent.data = Uri.parse("package:" + applicationContext.packageName)
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        startActivity(intent)
+                        result.success(null)
+                    } catch (e: Exception) {
+                        result.error("OPEN_APP_SETTINGS_ERROR", e.message, null)
                     }
                 }
                 else -> result.notImplemented()

--- a/android/app/src/main/kotlin/onl/coconut/vault/MainActivity.kt
+++ b/android/app/src/main/kotlin/onl/coconut/vault/MainActivity.kt
@@ -24,7 +24,7 @@ import android.util.Log
 
 class MainActivity: FlutterFragmentActivity() {
     private val CHANNEL = "onl.coconut.vault/os"
-    private val SYSTEM_SETTINGS_CHANNEL = "app-settings"
+    private val CHANNEL_OPEN_APP_SETTINGS = "app-settings"
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -79,7 +79,7 @@ class MainActivity: FlutterFragmentActivity() {
             }
         }
 
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SYSTEM_SETTINGS_CHANNEL).setMethodCallHandler { call, result ->
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL_OPEN_APP_SETTINGS).setMethodCallHandler { call, result ->
             when (call.method) {
                 "openSecuritySettings" -> {
                     try {

--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -17,6 +17,7 @@ hour: "hour"
 minute: "min"
 second: "sec"
 settings: "Settings"
+OK: "OK"
 confirm: "Confirm"
 complete: "Complete"
 cancel: "Cancel"
@@ -50,6 +51,7 @@ email_subject: "[Coconut Vault] Inquiry"
 delete_vault: "Delete Wallets"
 delete_vault_description: "This will delete all saved wallet information.\nAre you sure you want to delete?"
 verify_security: "Verifying security..."
+go_to_settings: "Go to Settings"
 
 sign_completion: "Signed"
 sign: "Sign"
@@ -403,6 +405,9 @@ unit_bottom_sheet:
 
 coconut_qr_scanner:
   reading_extra_data: "Reading additional data to collect\nPlease keep scanning"
+  camera_error:
+    title: "Camera Access Unavailable"
+    need_camera_permission: "Please allow camera access in Settings."
 
 # lib/screens/setting
 app_info_screen:

--- a/assets/i18n/jp.i18n.yaml
+++ b/assets/i18n/jp.i18n.yaml
@@ -18,6 +18,7 @@ hour: "時間"
 minute: "分"
 second: "秒"
 settings: "設定"
+OK: "OK"
 confirm: "確認"
 complete: "完了"
 cancel: "キャンセル"
@@ -50,6 +51,7 @@ email_subject: "[ココナッツボルト] お問い合わせ"
 delete_vault: "ウォレットを削除"
 delete_vault_description: "ウォレットを削除すると、すべての情報が初期化されます。\n本当に削除しますか？"
 verify_security: "セキュリティチェック中..."
+go_to_settings: "設定を開く"
 
 sign_completion: "署名完了"
 sign: "署名"
@@ -403,6 +405,9 @@ unit_bottom_sheet:
 
 coconut_qr_scanner:
   reading_extra_data: "収集する追加データを読み取り中\nスキャンを続けてください"
+  camera_error:
+    title: "カメラを使用できません"
+    need_camera_permission: "設定でカメラの使用を許可してください。"
 
 # lib/screens/setting
 app_info_screen:

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -18,6 +18,7 @@ hour: "시간"
 minute: "분"
 second: "초"
 settings: "설정"
+OK: "확인"
 confirm: "확인"
 complete: "완료"
 cancel: "취소"
@@ -50,6 +51,7 @@ email_subject: "[코코넛 볼트] 이용 관련 문의"
 delete_vault: "지갑 삭제"
 delete_vault_description: "지갑을 삭제하면 모든 정보가 초기화됩니다.\n정말로 삭제하시겠어요?"
 verify_security: "보안 검사 중..."
+go_to_settings: "설정하러 가기"
 
 sign_completion: "서명 완료"
 sign: "서명하기"
@@ -404,6 +406,9 @@ unit_bottom_sheet:
 
 coconut_qr_scanner:
   reading_extra_data: "거의 다 읽었어요\n남은 데이터를 마저 스캔해 주세요"
+  camera_error:
+    title: "카메라 사용 불가"
+    need_camera_permission: "설정에서 카메라 권한을 허용해 주세요."
 
 # lib/screens/setting
 app_info_screen:

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -42,5 +42,11 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+
+    target.build_configurations.each do |config|
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        'PERMISSION_CAMERA=1'
+      ]
+    end
   end
 end

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -91,9 +91,39 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		C21791F92EA798F9009D98B6 /* ja.lproj */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ja.lproj; sourceTree = "<group>"; };
-		DEFFF1C72E419803001314B6 /* ko.lproj */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ko.lproj; sourceTree = "<group>"; };
-		DEFFF1D02E419996001314B6 /* en.lproj */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = en.lproj; sourceTree = "<group>"; };
+		C21791F92EA798F9009D98B6 /* ja.lproj */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = ja.lproj;
+			sourceTree = "<group>";
+		};
+		DEFFF1C72E419803001314B6 /* ko.lproj */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = ko.lproj;
+			sourceTree = "<group>";
+		};
+		DEFFF1D02E419996001314B6 /* en.lproj */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = en.lproj;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -252,6 +282,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				3A357562303AD3455E4DACD1 /* [CP] Embed Pods Frameworks */,
+				9BFC50D98E3544089AAE5B5F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -400,6 +431,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		9BFC50D98E3544089AAE5B5F /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9D860CF210E05A5F5336C7D6 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/lib/providers/preference_provider.dart
+++ b/lib/providers/preference_provider.dart
@@ -16,6 +16,14 @@ class PreferenceProvider extends ChangeNotifier {
   late List<int> _favoriteVaultIds;
   List<int> get favoriteVaultIds => _favoriteVaultIds;
 
+  /// 언어 설정
+  late String _language;
+  String get language => _language;
+
+  bool get isKorean => _language == "kr";
+  bool get isEnglish => _language == "en";
+  bool get isJapanese => _language == "jp";
+
   bool get isSigningOnlyMode => getVaultMode() == VaultMode.signingOnly;
 
   late (double?, double?) _signingModeEdgePanelPos;
@@ -25,6 +33,8 @@ class PreferenceProvider extends ChangeNotifier {
     _vaultOrder = _getVaultOrder();
     _favoriteVaultIds = _getFavoriteVaultIds();
     _signingModeEdgePanelPos = getSigningModeEdgePanelPos();
+
+    _language = _getLanguage();
   }
 
   /// 지갑 순서 불러오기
@@ -116,5 +126,14 @@ class PreferenceProvider extends ChangeNotifier {
     final posY = _sharedPrefs.getDouble(SharedPrefsKeys.kSigningModeEdgePanelPosY);
     _signingModeEdgePanelPos = (posX, posY);
     return _signingModeEdgePanelPos;
+  }
+
+  String _getLanguage() {
+    final lang = _sharedPrefs.getString(SharedPrefsKeys.kLanguage);
+
+    if (lang.isEmpty) {
+      return "en";
+    }
+    return lang;
   }
 }

--- a/lib/screens/airgap/psbt_scanner_screen.dart
+++ b/lib/screens/airgap/psbt_scanner_screen.dart
@@ -64,14 +64,9 @@ class _PsbtScannerScreenState extends State<PsbtScannerScreen> {
     _initializeQrScanDataHandler();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      context.loaderOverlay.show();
-
-      Future.delayed(const Duration(milliseconds: 1000), () {
-        // fixme 추후 QRCodeScanner가 개선되면 QRCodeScanner 의 카메라 뷰 생성 완료된 콜백 찾아 progress hide 합니다. 현재는 1초 후 hide
-        if (mounted) {
-          context.loaderOverlay.hide();
-        }
-      });
+      if (controller == null) {
+        context.loaderOverlay.show();
+      }
     });
   }
 
@@ -93,6 +88,7 @@ class _PsbtScannerScreenState extends State<PsbtScannerScreen> {
 
   void _setQRViewController(MobileScannerController qrViewcontroller) {
     controller = qrViewcontroller;
+    if (mounted && context.loaderOverlay.visible) context.loaderOverlay.hide();
   }
 
   Future<void> _showErrorDialog(String message) async {
@@ -354,6 +350,10 @@ class _PsbtScannerScreenState extends State<PsbtScannerScreen> {
     }
   }
 
+  void _onScannerInitError(Exception exception) {
+    if (mounted) context.loaderOverlay.hide();
+  }
+
   @override
   Widget build(BuildContext context) {
     return CustomLoadingOverlay(
@@ -380,6 +380,7 @@ class _PsbtScannerScreenState extends State<PsbtScannerScreen> {
                 setQrViewController: _setQRViewController,
                 onComplete: _onCompletedScanning,
                 onFailed: onFailedScanning,
+                onScannerInitError: _onScannerInitError,
                 qrDataHandler: _scanDataHandler,
               ),
             ),

--- a/lib/screens/airgap/psbt_scanner_screen.dart
+++ b/lib/screens/airgap/psbt_scanner_screen.dart
@@ -16,6 +16,7 @@ import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/bc_ur_qr_sca
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
 import 'package:coconut_vault/widgets/custom_loading_overlay.dart';
 import 'package:coconut_vault/widgets/custom_tooltip.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:coconut_vault/providers/wallet_provider.dart';
 import 'package:coconut_vault/utils/vibration_util.dart';
@@ -361,6 +362,15 @@ class _PsbtScannerScreenState extends State<PsbtScannerScreen> {
           title: widget.hardwareWalletType?.displayName ?? t.sign,
           context: context,
           backgroundColor: CoconutColors.white,
+          actionButtonList: [
+            IconButton(
+              icon: const Icon(CupertinoIcons.camera_rotate, size: 22),
+              color: CoconutColors.black,
+              onPressed: () {
+                controller?.switchCamera();
+              },
+            ),
+          ],
         ),
         body: Stack(
           children: [

--- a/lib/screens/vault_creation/multisig/bsms_scanner_base.dart
+++ b/lib/screens/vault_creation/multisig/bsms_scanner_base.dart
@@ -11,6 +11,7 @@ import 'package:coconut_vault/widgets/button/fixed_bottom_button.dart';
 import 'package:coconut_vault/widgets/custom_loading_overlay.dart';
 import 'package:coconut_vault/widgets/custom_tooltip.dart';
 import 'package:coconut_vault/widgets/overlays/scanner_overlay.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:provider/provider.dart';
@@ -148,6 +149,15 @@ abstract class BsmsScannerBase<T extends StatefulWidget> extends State<T> {
           context: context,
           isBackButton: showBackButton,
           isBottom: useBottomAppBar,
+          actionButtonList: [
+            IconButton(
+              icon: const Icon(CupertinoIcons.camera_rotate, size: 22),
+              color: CoconutColors.black,
+              onPressed: () {
+                controller?.switchCamera();
+              },
+            ),
+          ],
         ),
         body: SafeArea(top: false, child: _buildStack(context)),
       ),

--- a/lib/screens/vault_creation/single_sig/seed_qr_import_screen.dart
+++ b/lib/screens/vault_creation/single_sig/seed_qr_import_screen.dart
@@ -9,9 +9,9 @@ import 'package:coconut_vault/model/multisig/multisig_signer.dart';
 import 'package:coconut_vault/providers/app_lifecycle_state_provider.dart';
 import 'package:coconut_vault/providers/visibility_provider.dart';
 import 'package:coconut_vault/screens/vault_creation/single_sig/seed_qr_confirmation_screen.dart';
-import 'package:coconut_vault/utils/popup_util.dart';
 import 'package:coconut_vault/widgets/custom_tooltip.dart';
 import 'package:crypto/crypto.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:qr_code_scanner_plus/qr_code_scanner_plus.dart';
@@ -67,6 +67,15 @@ class _SeedQrImportScreenState extends State<SeedQrImportScreen> {
         context: context,
         title: t.seed_qr_import_screen.title,
         backgroundColor: CoconutColors.white,
+        actionButtonList: [
+          IconButton(
+            icon: const Icon(CupertinoIcons.camera_rotate, size: 22),
+            color: CoconutColors.black,
+            onPressed: () {
+              controller?.flipCamera();
+            },
+          ),
+        ],
       ),
       body: Stack(
         children: [

--- a/lib/screens/vault_creation/single_sig/seed_qr_import_screen.dart
+++ b/lib/screens/vault_creation/single_sig/seed_qr_import_screen.dart
@@ -60,7 +60,10 @@ class _SeedQrImportScreenState extends State<SeedQrImportScreen> {
       });
 
       if (!status.isGranted) {
-        _showCameraPermissionDialog();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          _showCameraPermissionDialog();
+        });
       }
     }
   }

--- a/lib/utils/app_settings_util.dart
+++ b/lib/utils/app_settings_util.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter/services.dart';
+
+Future<void> openAppSettings() async {
+  if (Platform.isIOS) {
+    const url = 'app-settings:';
+    if (await canLaunchUrl(Uri.parse(url))) {
+      await launchUrl(Uri.parse(url));
+    }
+  } else if (Platform.isAndroid) {
+    const channel = MethodChannel('app-settings');
+    channel.invokeMethod('openAppSettings');
+  }
+}

--- a/lib/utils/device_secure_checker.dart
+++ b/lib/utils/device_secure_checker.dart
@@ -26,7 +26,7 @@ Future<void> openSystemSecuritySettings(
   String buttonText = '',
 }) async {
   if (Platform.isAndroid) {
-    const channel = MethodChannel('system_settings');
+    const channel = MethodChannel('app-settings');
     await channel.invokeMethod('openSecuritySettings');
   } else if (Platform.isIOS) {
     // 다이얼로그 표시 후 iOS는 앱 설정 화면으로 이동

--- a/lib/widgets/animated_qr/coconut_qr_scanner.dart
+++ b/lib/widgets/animated_qr/coconut_qr_scanner.dart
@@ -19,6 +19,7 @@ class CoconutQrScanner extends StatefulWidget {
   final Function(MobileScannerController) setQrViewController;
   final Function(dynamic) onComplete;
   final Function(String) onFailed;
+  final Function(MobileScannerException)? onScannerInitError;
   final Color borderColor;
   final IQrScanDataHandler qrDataHandler;
 
@@ -29,6 +30,7 @@ class CoconutQrScanner extends StatefulWidget {
     required this.onFailed,
     required this.qrDataHandler,
     this.borderColor = CoconutColors.white,
+    this.onScannerInitError,
   });
 
   @override
@@ -185,6 +187,10 @@ class _CoconutQrScannerState extends State<CoconutQrScanner> with SingleTickerPr
               controller: _controller!,
               onDetect: _onDetect,
               errorBuilder: (context, error) {
+                if (widget.onScannerInitError != null) {
+                  widget.onScannerInitError!(error);
+                }
+
                 if (error.errorCode == MobileScannerErrorCode.permissionDenied && !_isShowedCameraPermissionDialog) {
                   _isShowedCameraPermissionDialog = true;
                   WidgetsBinding.instance.addPostFrameCallback((_) async {

--- a/lib/widgets/animated_qr/coconut_qr_scanner.dart
+++ b/lib/widgets/animated_qr/coconut_qr_scanner.dart
@@ -1,10 +1,13 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/providers/app_lifecycle_state_provider.dart';
+import 'package:coconut_vault/providers/preference_provider.dart';
+import 'package:coconut_vault/utils/app_settings_util.dart';
 import 'package:coconut_vault/utils/logger.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_fragmented_qr_scan_data_handler.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/scan_data_handler_exceptions.dart';
+import 'package:coconut_vault/widgets/custom_dialog.dart';
 import 'package:coconut_vault/widgets/overlays/scanner_overlay.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
@@ -40,6 +43,7 @@ class _CoconutQrScannerState extends State<CoconutQrScanner> with SingleTickerPr
   double scannerLoadingVerticalPos = 0;
   bool _showLoadingBar = false;
   bool _isFirstScanData = true;
+  bool _isShowedCameraPermissionDialog = false;
 
   MobileScannerController? _controller;
 
@@ -177,11 +181,39 @@ class _CoconutQrScannerState extends State<CoconutQrScanner> with SingleTickerPr
       builder: (BuildContext context, BoxConstraints constraints) {
         return Stack(
           children: [
-            MobileScanner(controller: _controller, onDetect: _onDetect),
+            MobileScanner(
+              controller: _controller!,
+              onDetect: _onDetect,
+              errorBuilder: (context, error) {
+                if (error.errorCode == MobileScannerErrorCode.permissionDenied && !_isShowedCameraPermissionDialog) {
+                  _isShowedCameraPermissionDialog = true;
+                  WidgetsBinding.instance.addPostFrameCallback((_) async {
+                    if (!mounted) return;
+                    await _showCameraPermissionDialog();
+                    if (!mounted) return;
+                    Navigator.pop(context);
+                  });
+                }
+                return Center(child: Text(error.errorCode.message));
+              },
+            ),
             const ScannerOverlay(),
             _buildProgressOverlay(context),
           ],
         );
+      },
+    );
+  }
+
+  Future<void> _showCameraPermissionDialog() async {
+    await showConfirmDialog(
+      context,
+      context.read<PreferenceProvider>().language,
+      t.coconut_qr_scanner.camera_error.title,
+      t.coconut_qr_scanner.camera_error.need_camera_permission,
+      rightButtonText: t.go_to_settings,
+      onTapRight: () {
+        openAppSettings();
       },
     );
   }

--- a/lib/widgets/custom_dialog.dart
+++ b/lib/widgets/custom_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
+import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 
@@ -38,4 +39,45 @@ class CustomDialogs {
       },
     );
   }
+}
+
+Future<void> showConfirmDialog(
+  BuildContext context,
+  String languageCode,
+  String title,
+  String description, {
+  String? leftButtonText,
+  String? rightButtonText,
+  Function? onTapLeft,
+  Function? onTapRight,
+  bool barrierDismissible = true,
+}) async {
+  await showDialog(
+    context: context,
+    barrierDismissible: barrierDismissible,
+    builder: (BuildContext context) {
+      return CoconutPopup(
+        languageCode: languageCode,
+        title: title,
+        backgroundColor: CoconutColors.white.withOpacity(0.7),
+        description: description,
+        descriptionPadding: const EdgeInsets.only(left: 16, right: 16, top: 12, bottom: 12),
+        insetPadding: const EdgeInsets.symmetric(horizontal: 50),
+        leftButtonText: leftButtonText ?? t.cancel,
+        leftButtonColor: CoconutColors.black,
+        rightButtonText: rightButtonText ?? t.OK,
+        rightButtonColor: CoconutColors.black,
+        onTapLeft:
+            onTapLeft ??
+            () {
+              Navigator.pop(context);
+            },
+        onTapRight:
+            onTapRight ??
+            () {
+              Navigator.pop(context);
+            },
+      );
+    },
+  );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ dependencies:
   flutter_keyboard_visibility: ^6.0.0
   base32: ^2.2.0
   archive: ^4.0.7
+  permission_handler: ^12.0.1
 
 dev_dependencies:
   flutter_oss_licenses: ^3.0.2


### PR DESCRIPTION
## 변경사항
1. 카메라 권한 없을 시 권한 설정 팝업 유틸 구현
2. mobile scanner 사용 화면에서 카메라 권한 팝업 적용(bsms_scanner_base)
3. qr_code_scanner_plus 사용 화면에서 카메라 권한 설정 팝업 구현(seed_qr_import_screen)

##특이사항
qr_code_scanner_plus 사용 시 라이브러리 버그로 인해 applifecycle 무한 루프 문제 발생
-> _buildQrView를 하기 이전에 권한 설정부터 체크하여 해당 문제 우회적으로 해결