### PR TITLE
Fix/288 android security folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@
    ```bash
       dart pub run build_runner clean && dart pub run build_runner build --delete-conflicting-outputs && dart pub run slang
    ```
+4. Kotlin 파일 포맷팅 방법 (VSCode or VScode ext IDE like cursor, windsurf)
+   - vscode extension: ktfmtter 설치
+   - 터미널에 ```/usr/libexec/java_home``` 명령어로 java path 얻기
+   - .vscode/settings.json에 아래 내용 추가 (.vscode/settings.sample.json파일 생성 후 로컬에서 관리 추천)
+   ```
+   "java.configuration.runtimes": [
+        {
+            "name": "JavaSE-18", // 사용중인 java 버전 이름 입력
+            "path": [위에서 명령어로 얻은 java home path 입력],
+            "default": true
+        }
+    ],
+    "ktfmtter.ktfmtVersion": "0.47",
+    "ktfmtter.style": "google",
+    "[kotlin]": {
+        "editor.defaultFormatter": "shape-app.ktfmtter"
+    }
+   ```
+   - Kotling 파일에서 ```Shift+Option+F``` 단축키로 포맷팅 / 위 설정은 ‼️커밋 금지‼️
+
 
 ### 실행하기
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,7 +44,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "onl.coconut.vault"
-    compileSdk 35
+    compileSdk 36
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -116,4 +116,5 @@ flutter {
 
 dependencies {
     implementation "androidx.core:core-splashscreen:1.0.0"
+    implementation "androidx.biometric:biometric:1.1.0"
 }

--- a/assets/i18n/en.i18n.yaml
+++ b/assets/i18n/en.i18n.yaml
@@ -901,6 +901,8 @@ permission:
   secure_zone_authentication:
     title: "Secure Module Access"
     description: "Authentication is required to access the secure module."
+  android_security_folder_auth:
+    description: "‼️ If you are using Security Folder, please authenticate with PIN/Pattern/Password."
 
 alert:
   delete_vault:

--- a/assets/i18n/jp.i18n.yaml
+++ b/assets/i18n/jp.i18n.yaml
@@ -899,6 +899,8 @@ permission:
   secure_zone_authentication:
     title: "セキュアモジュールへのアクセス"
     description: "セキュアモジュールにアクセスするには認証が必要です。"
+  android_security_folder_auth:
+    description: "‼️ Security Folderを使用している場合は、PIN/Pattern/Password認証でアクセスしてください。"
 
 alert:
   delete_vault: 

--- a/assets/i18n/kr.i18n.yaml
+++ b/assets/i18n/kr.i18n.yaml
@@ -904,6 +904,8 @@ permission:
   secure_zone_authentication:
     title: "보안 모듈 접근"
     description: "보안 모듈 접근을 위해 인증이 필요해요."
+  android_security_folder_auth:
+    description: "‼️ 보안 폴더를 사용중이시면 반드시 PIN/패턴/패스워드로 인증해 주세요."
 
 alert: 
   delete_vault: 

--- a/docs/features/repository/secure_zone_repository.md
+++ b/docs/features/repository/secure_zone_repository.md
@@ -13,3 +13,7 @@ AOS, iOS: 이전 데이터 무효화 (제거 후 같은 걸로 설정해도 이�
 
 ## 기기 패스코드 변경 시
 AOS, iOS: 기존 데이터 영향 없음
+
+## AOS 보안 폴더 내에서 '생체 인증'으로 secure_zone 접근 권한 갱신 안되는 문제
+삼성에서 보안 폴더 기능을 제공하기 시작한 건 Android 13 (API level 33) 이상부터 입니다.
+삼성 휴대폰 One UI 8 (Android 16 / API level 36) 미만 기기에서, 보안 폴더 내에서는 '생체 인증'으로 KeyStore 접근을 위한 인증이 안되는 문제가 있습니다. 따라서 안드로이드에서 2차 AUTH_NEEDED 예외 발생 시 'PIN/Pattern/Password'로 인증을 강제하는 로직을 추가했습니다.

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -26,7 +26,6 @@ class AuthProvider extends ChangeNotifier {
   static String unlockAvailableAtKey = SharedPrefsKeys.kUnlockAvailableAt;
   static String turnKey = SharedPrefsKeys.kPinInputTurn;
   static String currentAttemptKey = SharedPrefsKeys.kPinInputCurrentAttemptCount;
-  static const _osChannel = MethodChannel(methodChannelOS);
 
   final SharedPrefsRepository _sharedPrefs = SharedPrefsRepository();
   final SecureStorageRepository _storageService = SecureStorageRepository();

--- a/lib/services/secure_zone/android/hardware_backed_keystore.dart
+++ b/lib/services/secure_zone/android/hardware_backed_keystore.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:coconut_vault/constants/method_channel.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/model/exception/user_canceled_auth_exception.dart';
 import 'package:coconut_vault/services/secure_zone/secure_zone_keystore.dart';
@@ -88,12 +91,29 @@ class HardwareBackedKeystore extends SecureZoneKeystore {
         rethrow;
       }
 
-      // 첫 번째 인증 시도
       if (!await _authenticate()) {
         throw UserCanceledAuthException();
       }
 
-      return await operation();
+      try {
+        return await operation();
+      } on PlatformException catch (e) {
+        if (Platform.isIOS || e.code != 'AUTH_NEEDED' || !autoAuth) {
+          rethrow;
+        }
+
+        // 삼성 휴대폰 One UI 8 (Android 16 / API level 36) 미만 기기에서
+        // **보안 폴더 내부** 에서 앱 실행 시 앱에서 설정한 300초 유효시간 만료 후
+        // "생체인증(Face/Fingerprint)"으로 인증 시 갱신 실패
+        // 하지만 "PIN/Pattern/Password"으로 인증 시에는 갱신 성공
+        // 따라서 "PIN/Pattern/Password"으로 인증을 한번 더 요청
+        // 삼성에서 보안 폴더는 Android 13 (API level 33) 이상부터 제공
+        if (!await _authenticateWithDeviceCredential()) {
+          throw UserCanceledAuthException();
+        }
+
+        return await operation();
+      }
     }
   }
 
@@ -101,6 +121,24 @@ class HardwareBackedKeystore extends SecureZoneKeystore {
     return await ch.invokeMethod<bool>('authenticateForKeystore', {
           'title': t.permission.secure_zone_authentication.title,
           'description': t.permission.secure_zone_authentication.description,
+        }) ??
+        false;
+  }
+
+  /// Authenticate using device credentials on Android.
+  ///
+  /// - API >= 30 (R): 30(API R) 이상에서는 `BiometricPrompt` `DEVICE_CREDENTIAL`옵션으로 사용 가능
+  /// - API < 30: 30(API R) 미만에서는 기존의 `authenticateForKeystore` 사용하되 반드시 PIN/Pattern/Password로 인증하라고 안내 문구를 변경
+  ///             (삼성 휴대폰 One UI 8 (Android 16 / API level 36) 미만 기기에서 "보안 폴더 내"에서 생체인증 시 인증 갱신이 안되기 때문)
+  ///
+  /// See `HardwareBackedKeystorePlugin.kt` for the native implementation details.
+  Future<bool> _authenticateWithDeviceCredential() async {
+    assert(Platform.isAndroid);
+
+    return await ch.invokeMethod<bool>('authenticateWithDeviceCredential', {
+          'title': t.permission.secure_zone_authentication.title,
+          'descriptionAbove30': t.permission.secure_zone_authentication.description,
+          'descriptionUnder30': t.permission.android_security_folder_auth.description,
         }) ??
         false;
   }


### PR DESCRIPTION
삼성 휴대폰 One UI 8 (Android 16 / API level 36) 미만 기기에서
 **보안 폴더 내부** 에서 앱 실행 시 앱에서 설정한 300초 유효시간 만료 후
 "생체인증(Face/Fingerprint)"으로 인증 시 갱신 실패
하지만 "PIN/Pattern/Password"으로 인증 시에는 갱신 성공
**_따라서 "PIN/Pattern/Password"으로 인증을 한번 더 요청_**
삼성에서 보안 폴더는 Android 13 (API level 33) 이상부터 제공

테스트방법: TS49 

-----
위 변경사항과 별도로, 
kotlin 파일 포맷팅 방법에 대한 안내도 추가했습니다.

ISSUE #288 