### PR TITLE
지갑 추가 > 디바이스 비번 변경 > 변경 감지 > 데이터 삭제 > 지갑 추가 후 목록에 불필요한 skeleton loading이 보임

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -348,7 +348,6 @@ class _CoconutVaultAppState extends State<CoconutVaultApp> with SingleTickerProv
         return DevicePasswordCheckerScreen(
           state: DevicePasswordCheckerScreenState.devicePasswordChanged,
           onComplete: () async {
-            await _handleDevicePasswordChangedOnResume();
             _updateEntryFlow(AppEntryFlow.vaultHome);
           },
         );
@@ -620,17 +619,6 @@ class _CoconutVaultAppState extends State<CoconutVaultApp> with SingleTickerProv
   }) {
     final args = ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>? ?? defaultArgs ?? {};
     return builder(args);
-  }
-
-  /// onAppGoActive에서 기기 비밀번호 변경 시 볼트 초기화 처리
-  Future<void> _handleDevicePasswordChangedOnResume() async {
-    try {
-      // 볼트 초기화 (앱 최초실행 여부, 볼트 모드는 유지)
-      await SecureZoneManager().deleteStoredData(authProvider);
-    } catch (e) {
-      debugPrint('볼트 초기화 실패: $e');
-      // 볼트 초기화 실패 시에도 계속 진행
-    }
   }
 
   @override

--- a/lib/providers/preference_provider.dart
+++ b/lib/providers/preference_provider.dart
@@ -33,7 +33,6 @@ class PreferenceProvider extends ChangeNotifier {
     _vaultOrder = _getVaultOrder();
     _favoriteVaultIds = _getFavoriteVaultIds();
     _signingModeEdgePanelPos = getSigningModeEdgePanelPos();
-
     _language = _getLanguage();
   }
 
@@ -135,5 +134,11 @@ class PreferenceProvider extends ChangeNotifier {
       return "en";
     }
     return lang;
+  }
+
+  void reloadRelatedToVault() {
+    _vaultOrder = _getVaultOrder();
+    _favoriteVaultIds = _getFavoriteVaultIds();
+    notifyListeners();
   }
 }

--- a/lib/providers/visibility_provider.dart
+++ b/lib/providers/visibility_provider.dart
@@ -16,7 +16,6 @@ class VisibilityProvider extends ChangeNotifier {
   late bool _isBtcUnit;
 
   bool get hasSeenGuide => _hasSeenGuide;
-  int get walletCount => _walletCount;
   bool get isPassphraseUseEnabled => _isPassphraseUseEnabled;
   String get language => _language;
   bool get isKorean => _language == 'kr';
@@ -215,5 +214,9 @@ class VisibilityProvider extends ChangeNotifier {
       SharedPrefsRepository().setInt(SharedPrefsKeys.vaultListLength, _walletCount);
     }
     _isSigningOnlyMode = isSigningOnlyMode;
+  }
+
+  void reloadRelatedToVault() {
+    _walletCount = SharedPrefsRepository().getInt(SharedPrefsKeys.vaultListLength) ?? 0;
   }
 }

--- a/lib/providers/wallet_provider.dart
+++ b/lib/providers/wallet_provider.dart
@@ -562,6 +562,12 @@ class WalletProvider extends ChangeNotifier {
     return target;
   }
 
+  Future<void> reloadRelatedToVault() async {
+    _isVaultListLoading = false;
+    _isVaultsLoaded = false;
+    await loadVaultList();
+  }
+
   // 7) 오버라이드/생명주기
   @override
   void dispose() {

--- a/lib/screens/precheck/device_password_checker_screen.dart
+++ b/lib/screens/precheck/device_password_checker_screen.dart
@@ -1,7 +1,9 @@
 import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/providers/auth_provider.dart';
+import 'package:coconut_vault/providers/preference_provider.dart';
 import 'package:coconut_vault/providers/visibility_provider.dart';
+import 'package:coconut_vault/providers/wallet_provider.dart';
 import 'package:coconut_vault/services/secure_zone/secure_zone_availability_checker.dart';
 import 'package:coconut_vault/utils/device_secure_checker.dart' as device_secure_checker;
 import 'package:coconut_vault/widgets/button/fixed_bottom_button.dart';
@@ -215,8 +217,18 @@ class _DevicePasswordCheckerScreenState extends State<DevicePasswordCheckerScree
         );
         break;
       case DevicePasswordCheckerScreenState.devicePasswordChanged:
-        final authProvider = Provider.of<AuthProvider>(context, listen: false);
-        final result = await SecureZoneManager().deleteStoredData(authProvider);
+        WalletProvider? walletProvider;
+        try {
+          walletProvider = context.read<WalletProvider>();
+        } catch (_) {
+          // igrore
+        }
+        final result = await SecureZoneManager().deleteStoredData(
+          context.read<AuthProvider>(),
+          walletProvider,
+          context.read<VisibilityProvider>(),
+          context.read<PreferenceProvider>(),
+        );
         if (mounted && result) {
           widget.onComplete();
         }

--- a/lib/screens/precheck/jail_break_detection_screen.dart
+++ b/lib/screens/precheck/jail_break_detection_screen.dart
@@ -2,7 +2,9 @@ import 'package:coconut_design_system/coconut_design_system.dart';
 import 'package:coconut_vault/constants/shared_preferences_keys.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/providers/auth_provider.dart';
+import 'package:coconut_vault/providers/preference_provider.dart';
 import 'package:coconut_vault/providers/visibility_provider.dart';
+import 'package:coconut_vault/providers/wallet_provider.dart';
 import 'package:coconut_vault/repository/shared_preferences_repository.dart';
 import 'package:coconut_vault/services/secure_zone/secure_zone_availability_checker.dart';
 import 'package:coconut_vault/widgets/button/fixed_bottom_button.dart';
@@ -162,7 +164,18 @@ class _JailBreakDetectionScreenState extends State<JailBreakDetectionScreen> {
       ),
       isActive: true,
       onButtonClicked: () async {
-        final result = await SecureZoneManager().deleteStoredData(context.read<AuthProvider>());
+        WalletProvider? walletProvider;
+        try {
+          walletProvider = context.read<WalletProvider>();
+        } catch (_) {
+          // igrore
+        }
+        final result = await SecureZoneManager().deleteStoredData(
+          context.read<AuthProvider>(),
+          walletProvider,
+          context.read<VisibilityProvider>(),
+          context.read<PreferenceProvider>(),
+        );
         if (!mounted || !result) return;
         widget.onReset?.call();
       },


### PR DESCRIPTION
# 버그 재현 방법
1. 안전 저장 모드 > 지갑 2개 추가 
2. 디바이스 비번 변경 후 앱 재실행 
3. 앱에서 비번 변경됨을 감지하고 DevicePasswordCheckerScreen으로 이동 > 해당 화면의 맨 하단에 '데이터 삭제' 누르면 
데이터 초기화 후 홈 화면으로 이동
4. 지갑 추가 시 preferenceProvider의 _vaultOrder, _favoriteVaultIds가 초기화 전 데이터를 갖고 있어서 2개의 skeleton wallet list가 보임 

# 해결 방법
DevicePasswordCheckerScreen, JailBreakDetectionScreen에서 감지가 되고 '데이터 삭제'를 누르면 호출되는 함수인 
SecureZoneManager.deleteStoredData를 다음 방법으로 수정 

1. 매개변수로 walletProvider, visibilityProvider, preferenceProvider를 받아서, 초기화 후 업데이트 해야 하는 정보를 다시 로드하는 
reloadRelatedToVault 함수를 호출. 

2. 사용자가 선택한 언어, BTCUnit, Passphrase 사용 여부는 초기화될 필요가 없기 때문에 전체 데이터 삭제 후 복구될 수 있도록 함

기타 변경 사항에 대한 설명은 코멘트 참조 부탁드립니다. 

# 테스트 한 사항
[안드로이드/iOS] 지갑 안전저장 모드 - 지갑 추가 - 기기 비번 변경 - 앱 진입 - 기기 비번 변경 감지 - 데이터 삭제 - 지갑 추가 -> 홈 화면에서 불필요한 지갑 목록이 보이는 버그가 사라짐을 확인
