### PR TITLE
[398] 계정 번호 변경 불가 오류

### DIFF
--- a/lib/isolates/wallet_isolates/wallet_isolates.dart
+++ b/lib/isolates/wallet_isolates/wallet_isolates.dart
@@ -421,8 +421,8 @@ class WalletIsolates {
   static Future<Map<String, dynamic>> deriveNewAccountVault(Map<String, dynamic> args) async {
     setNetworkType();
 
-    final Uint8List mnemonic = args['mnemonic'];
-    final Uint8List? passphrase = args['passphrase'];
+    final Uint8List originalMnemonic = args['mnemonic'];
+    final Uint8List? originalPassphrase = args['passphrase'];
     final String addressTypeName = args['addressTypeName'];
     final int currentAccountIndex = args['currentAccountIndex'];
     final int newAccountIndex = args['newAccountIndex'];
@@ -430,11 +430,19 @@ class WalletIsolates {
 
     final AddressType addressType = AddressType.getAddressTypeFromName(addressTypeName);
 
+    // Dual-copying to prevent data loss during memory erasure
+    final Uint8List mnemonicForVerify = Uint8List.fromList(originalMnemonic);
+    final Uint8List mnemonicForDerive = Uint8List.fromList(originalMnemonic);
+
+    final Uint8List? passphraseForVerify = originalPassphrase != null ? Uint8List.fromList(originalPassphrase) : null;
+    final Uint8List? passphraseForDerive = originalPassphrase != null ? Uint8List.fromList(originalPassphrase) : null;
+
     try {
+      // 1. Verify
       final SingleSignatureVault derivedVault = SingleSignatureVault.fromMnemonic(
-        mnemonic,
+        mnemonicForVerify,
         addressType: addressType,
-        passphrase: passphrase,
+        passphrase: passphraseForVerify,
         accountIndex: currentAccountIndex,
       );
 
@@ -445,10 +453,11 @@ class WalletIsolates {
         throw Exception('Invalid passphrase');
       }
 
+      // 2. New account
       final SingleSignatureVault updatedCoconutVault = SingleSignatureVault.fromMnemonic(
-        mnemonic,
+        mnemonicForDerive,
         addressType: addressType,
-        passphrase: passphrase,
+        passphrase: passphraseForDerive,
         accountIndex: newAccountIndex,
       );
 
@@ -459,10 +468,13 @@ class WalletIsolates {
       updatedCoconutVault.keyStore.wipeSeed();
       return result;
     } finally {
-      mnemonic.wipe();
-      if (passphrase != null) {
-        passphrase.wipe();
-      }
+      mnemonicForVerify.wipe();
+      mnemonicForDerive.wipe();
+      originalMnemonic.wipe();
+
+      passphraseForVerify?.wipe();
+      passphraseForDerive?.wipe();
+      originalPassphrase?.wipe();
     }
   }
 }

--- a/lib/isolates/wallet_isolates/wallet_isolates.dart
+++ b/lib/isolates/wallet_isolates/wallet_isolates.dart
@@ -421,8 +421,8 @@ class WalletIsolates {
   static Future<Map<String, dynamic>> deriveNewAccountVault(Map<String, dynamic> args) async {
     setNetworkType();
 
-    final Uint8List originalMnemonic = args['mnemonic'];
-    final Uint8List? originalPassphrase = args['passphrase'];
+    final Uint8List mnemonic = args['mnemonic'];
+    final Uint8List? passphrase = args['passphrase'];
     final String addressTypeName = args['addressTypeName'];
     final int currentAccountIndex = args['currentAccountIndex'];
     final int newAccountIndex = args['newAccountIndex'];
@@ -430,34 +430,26 @@ class WalletIsolates {
 
     final AddressType addressType = AddressType.getAddressTypeFromName(addressTypeName);
 
-    // Dual-copying to prevent data loss during memory erasure
-    final Uint8List mnemonicForVerify = Uint8List.fromList(originalMnemonic);
-    final Uint8List mnemonicForDerive = Uint8List.fromList(originalMnemonic);
-
-    final Uint8List? passphraseForVerify = originalPassphrase != null ? Uint8List.fromList(originalPassphrase) : null;
-    final Uint8List? passphraseForDerive = originalPassphrase != null ? Uint8List.fromList(originalPassphrase) : null;
+    SingleSignatureVault? derivedVault;
+    SingleSignatureVault? updatedCoconutVault;
 
     try {
-      // 1. Verify
-      final SingleSignatureVault derivedVault = SingleSignatureVault.fromMnemonic(
-        mnemonicForVerify,
+      derivedVault = SingleSignatureVault.fromMnemonic(
+        Uint8List.fromList(mnemonic),
         addressType: addressType,
-        passphrase: passphraseForVerify,
+        passphrase: passphrase != null ? Uint8List.fromList(passphrase) : null,
         accountIndex: currentAccountIndex,
       );
 
       final String derivedMfp = derivedVault.keyStore.masterFingerprint;
-      derivedVault.keyStore.wipeSeed();
-
       if (derivedMfp.toUpperCase() != expectedMfp.toUpperCase()) {
         throw Exception('Invalid passphrase');
       }
 
-      // 2. New account
-      final SingleSignatureVault updatedCoconutVault = SingleSignatureVault.fromMnemonic(
-        mnemonicForDerive,
+      updatedCoconutVault = SingleSignatureVault.fromMnemonic(
+        Uint8List.fromList(mnemonic),
         addressType: addressType,
-        passphrase: passphraseForDerive,
+        passphrase: passphrase != null ? Uint8List.fromList(passphrase) : null,
         accountIndex: newAccountIndex,
       );
 
@@ -465,16 +457,14 @@ class WalletIsolates {
         'descriptor': updatedCoconutVault.descriptor,
         'derivationPath': updatedCoconutVault.derivationPath,
       };
-      updatedCoconutVault.keyStore.wipeSeed();
       return result;
     } finally {
-      mnemonicForVerify.wipe();
-      mnemonicForDerive.wipe();
-      originalMnemonic.wipe();
-
-      passphraseForVerify?.wipe();
-      passphraseForDerive?.wipe();
-      originalPassphrase?.wipe();
+      derivedVault?.keyStore.wipeSeed();
+      updatedCoconutVault?.keyStore.wipeSeed();
+      mnemonic.wipe();
+      if (passphrase != null) {
+        passphrase.wipe();
+      }
     }
   }
 }

--- a/lib/screens/vault_creation/single_sig/seed_qr_confirmation_screen.dart
+++ b/lib/screens/vault_creation/single_sig/seed_qr_confirmation_screen.dart
@@ -8,6 +8,8 @@ import 'package:coconut_vault/isolates/wallet_isolates/wallet_isolates.dart';
 import 'package:coconut_vault/localization/strings.g.dart';
 import 'package:coconut_vault/model/multisig/multisig_signer.dart';
 import 'package:coconut_vault/providers/visibility_provider.dart';
+import 'package:coconut_vault/screens/settings/settings_screen.dart';
+import 'package:coconut_vault/widgets/bottom_sheet.dart';
 import 'package:coconut_vault/providers/wallet_creation/wallet_creation_provider.dart';
 import 'package:coconut_vault/providers/wallet_provider.dart';
 import 'package:coconut_vault/utils/passphrase_warning_util.dart';
@@ -336,6 +338,18 @@ class _SeedQrConfirmationScreenState extends State<SeedQrConfirmationScreen> {
   }
 
   Widget _buildPassphraseToggle() {
+    return Selector<VisibilityProvider, bool>(
+      selector: (context, provider) => provider.isPassphraseUseEnabled,
+      builder: (context, isPassphraseUseEnabled, child) {
+        if (isPassphraseUseEnabled) {
+          return _buildPassphraseToggleRow();
+        }
+        return _buildAdvancedModeNotice();
+      },
+    );
+  }
+
+  Widget _buildPassphraseToggleRow() {
     return Row(
       children: [
         CoconutLayout.spacing_200w,
@@ -355,6 +369,43 @@ class _SeedQrConfirmationScreenState extends State<SeedQrConfirmationScreen> {
           },
         ),
       ],
+    );
+  }
+
+  Widget _buildAdvancedModeNotice() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        color: CoconutColors.black.withValues(alpha: 0.06),
+      ),
+      child: Column(
+        children: [
+          Text(t.mnemonic_import_screen.need_advanced_mode),
+          GestureDetector(
+            onTap: () {
+              MyBottomSheet.showDraggableBottomSheet(
+                context: context,
+                showDragHandle: true,
+                initialChildSize: 0.9,
+                childBuilder: (scrollController) => SettingsScreen(scrollController: scrollController),
+              );
+            },
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                t.mnemonic_import_screen.open_settings,
+                style: const TextStyle(
+                  fontFamily: 'Pretendard',
+                  color: CoconutColors.black,
+                  decoration: TextDecoration.underline,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
#398 

## 변동 사항
- 시드QR 확인 화면에서 패스프레이즈 설정 미적용된 부분 수정
- 메모리 소거 시 데이터 유실 방지 로직으로 수정
  - 검증과 새 계정 업데이트 로직에 사용되는 변수 분리, 복사본 사용