### PR TITLE
fix: import the local ur package through a single URI

### DIFF
--- a/lib/providers/view_model/wallet_info/coordinator_bsms_qr_view_model.dart
+++ b/lib/providers/view_model/wallet_info/coordinator_bsms_qr_view_model.dart
@@ -6,7 +6,7 @@ import 'package:coconut_vault/model/multisig/multisig_vault_list_item.dart';
 import 'package:coconut_vault/providers/wallet_provider.dart';
 import 'package:coconut_vault/utils/bb_qr/bb_qr_encoder.dart';
 import 'package:flutter/material.dart';
-import 'package:coconut_vault/packages/bc-ur-dart/lib/cbor_lite.dart';
+import 'package:ur/cbor_lite.dart';
 import 'package:ur/ur.dart';
 import 'package:ur/ur_encoder.dart';
 

--- a/lib/services/blockchain_commons/account_descriptor/legacy_account_descriptor.dart
+++ b/lib/services/blockchain_commons/account_descriptor/legacy_account_descriptor.dart
@@ -1,6 +1,6 @@
 import 'dart:typed_data';
-import 'package:coconut_vault/packages/bc-ur-dart/lib/cbor_lite.dart';
 import 'package:coconut_vault/utils/conversion_util.dart';
+import 'package:ur/cbor_lite.dart';
 
 class Cosigner {
   final String label; // 예: "Alice Tapsigner"

--- a/lib/widgets/animated_qr/scan_data_handler/coordinator_bsms_qr_data_handler.dart
+++ b/lib/widgets/animated_qr/scan_data_handler/coordinator_bsms_qr_data_handler.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 
-import 'package:coconut_vault/packages/bc-ur-dart/lib/ur_decoder.dart';
 import 'package:coconut_vault/utils/bb_qr/bb_qr_decoder.dart';
 import 'package:coconut_vault/utils/logger.dart';
 import 'package:coconut_vault/utils/ur_bytes_converter.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
+import 'package:ur/ur_decoder.dart';
 
 /// Coordinator BSMS QR 데이터 처리 핸들러
 /// 허용: UR, BBQR, Json, Text

--- a/lib/widgets/animated_qr/scan_data_handler/signer_bsms_qr_data_handler.dart
+++ b/lib/widgets/animated_qr/scan_data_handler/signer_bsms_qr_data_handler.dart
@@ -1,11 +1,11 @@
 import 'package:coconut_lib/coconut_lib.dart';
 import 'package:coconut_vault/enums/hardware_wallet_type_enum.dart';
 import 'package:coconut_vault/model/exception/network_mismatch_exception.dart';
-import 'package:coconut_vault/packages/bc-ur-dart/lib/ur_decoder.dart';
 import 'package:coconut_vault/utils/bb_qr/bb_qr_decoder.dart';
 import 'package:coconut_vault/utils/bip/signer_bsms.dart';
 import 'package:coconut_vault/utils/ur_bytes_converter.dart';
 import 'package:coconut_vault/widgets/animated_qr/scan_data_handler/i_qr_scan_data_handler.dart';
+import 'package:ur/ur_decoder.dart';
 
 class SignerBsmsQrDataHandler implements IQrScanDataHandler {
   final HardwareWalletType? hardwareWalletType;

--- a/test/utils/qr_decoder_test.dart
+++ b/test/utils/qr_decoder_test.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 
-import 'package:coconut_vault/packages/bc-ur-dart/lib/ur_decoder.dart';
 import 'package:coconut_vault/utils/bb_qr/bb_qr_decoder.dart';
 import 'package:coconut_vault/utils/ur_bytes_converter.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ur/ur_decoder.dart';
 
 void main() {
   group('Coordinator Decoder(sparrow export option)', () {


### PR DESCRIPTION
## Problem

`pubspec.yaml` declares `lib/packages/bc-ur-dart` as the path dependency named `ur`, so its canonical import is `package:ur/...`. Five files instead reach the same directory through `package:coconut_vault/packages/bc-ur-dart/lib/...`.

The Dart VM identifies a class by its library URI. The same file reached through two different URIs therefore produces two unrelated `URDecoder` classes, and once both are loaded into a single VM, resolution fails.

## Reproduction on `develop`

```
flutter test test/utils/qr_decoder_test.dart test/utils/multisig_normalizer_test.dart
```

```
Lookup failed: URDecoder in package:ur/ur_decoder.dart
```

`test/utils/multisig_normalizer_test.dart` never loads, so only the 6 tests from `qr_decoder_test.dart` run. Each file passes on its own; the failure only appears when both are in the same VM.

## After this change

The same command loads both files and runs 20 tests.

That also surfaces 9 pre-existing failures in `multisig_normalizer_test.dart`. Those are **not** caused by this change — they were previously hidden because the file could not load at all. They look like fixture and expectation drift after two earlier commits:

- `3d030962` changed a scanner return type from `String` to `SignerBsms`, leaving four `contains()` assertions matching against objects.
- `e9e09ce1` made the converter dereference `.value` on CBOR-wrapped integers, while the mocks still pass raw `int`s.

I am happy to open a separate PR for those if useful.

## Scope

Import URIs only, in 5 files. No behavior change, no API change, no dependency change. Verified on the pinned SDK from `.fvmrc` (Flutter 3.29.1 / Dart 3.7.0).

## Note on production impact

I want to be precise rather than overstate this: the analyzer and compiler do not reject the duplication, and the two handler classes each use their own URI consistently, so I did **not** observe a runtime failure in the built app. The concrete, reproducible impact is the test VM failure above, plus duplicated library code and a latent hazard if a value ever crosses between the two identities.
